### PR TITLE
Change mozilla_aws_cli_config precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2019-11-20
+### Added
+* Add support for `$(maws)` syntax by removing carriage returns from output #122
+
+### Changed
+* Changed the precedence of the mozilla_aws_cli_config module such that if the
+  module is present it overrides settings in the ~/.maws/config file only for
+  settings that it asserts, leaving any additional settings set in the config
+  file intact
+
 ## [0.0.2] - 2019-11-19
 ### Added
-- Initial release of the mozilla-aws-cli tool
+* Initial release of the mozilla-aws-cli tool
 
-[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.2...HEAD
-<!-- [0.0.3]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.2...v0.0.3 -->
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.2...v0.1.0
 [0.0.2]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v0.0.2

--- a/mozilla_aws_cli/cli.py
+++ b/mozilla_aws_cli/cli.py
@@ -53,15 +53,13 @@ def validate_awscli_exists(ctx, param, value):
 
 
 def validate_config_file(ctx, param, filenames):
-    if mozilla_aws_cli_config is not None:
-        # Override the --config file contents
-        return mozilla_aws_cli_config.config
-
     if isinstance(filenames, basestring):
         filenames = [filenames]
 
-    if not any([os.path.exists(path) for path in filenames]):
-        raise click.BadParameter('Config files {} not found'.format(" ".join(filenames)))
+    if (not any([os.path.exists(path) for path in filenames]) and
+            mozilla_aws_cli_config is None):
+        raise click.BadParameter(
+            'Config files {} not found'.format(" ".join(filenames)))
 
     for filename in filenames:
         try:
@@ -78,6 +76,10 @@ def validate_config_file(ctx, param, filenames):
         except (configparser.Error):
             raise click.BadParameter(
                 'Config file {} is not a valid INI file.'.format(filename))
+    if mozilla_aws_cli_config is not None:
+        # Override the --config file contents with the mozilla_aws_cli_config
+        # module contents
+        config['DEFAULT'].update(mozilla_aws_cli_config.config)
 
     missing_settings = (
         {'client_id', 'idtoken_for_roles_url', 'well_known_url'} - set(config.defaults().keys()))


### PR DESCRIPTION
Changed the precedence of the mozilla_aws_cli_config module such that if the
module is present it overrides settings in the ~/.maws/config file only for
settings that it asserts, leaving any additional settings set in the config
file intact