### PR TITLE
Handle ExpiredTokenException correctly and restructure flow paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,3 +328,14 @@ mozilla-aws-cli-yoyodyne/
 │   └── __init__.py
 └── setup.py
 ```
+
+## Other projects in this space
+
+* https://github.com/aidan-/aws-cli-federator
+* https://github.com/Nike-Inc/gimme-aws-creds
+* https://github.com/sportradar/aws-azure-login
+* https://github.com/oktadeveloper/okta-aws-cli-assume-role
+* https://github.com/jmhale/okta-awscli
+* https://github.com/prolane/samltoawsstskeys
+* https://github.com/physera/onelogin-aws-cli
+* https://github.com/kxseven/axe/blob/master/bin/subcommands/axe-token-krb5formauth-create

--- a/mozilla_aws_cli/static/index.js
+++ b/mozilla_aws_cli/static/index.js
@@ -107,6 +107,9 @@ const pollState = setInterval(async () => {
         // show the roles
         const roles = await response.json();
         showRoles(roles);
+    } else if (remoteState.state === "restart_auth") {
+        setMessage("Redirecting to identity provider...");
+        window.location.replace(remoteState.value.idpUrl);
     } else if (remoteState.state === "aws_federate") {
         setMessage("Redirecting to AWS...");
         await shutdown();

--- a/mozilla_aws_cli/static/index.js
+++ b/mozilla_aws_cli/static/index.js
@@ -117,7 +117,7 @@ const pollState = setInterval(async () => {
         // insert the image to log out of AWS and then redirect there once
         // it has loaded
         $("#aws-federation-logout").on("load error", () => {
-            document.location = remoteState.value.awsFederationUrl;
+            window.location.replace = remoteState.value.awsFederationUrl;
         }).attr("src", "https://signin.aws.amazon.com/oauth?Action=logout");
     } else if (remoteState.state === "invalid_id") {
         setMessage("Another federation session has been detected. Shutting down.");

--- a/mozilla_aws_cli/sts_conn.py
+++ b/mozilla_aws_cli/sts_conn.py
@@ -9,6 +9,9 @@ from .cache import read_sts_credentials, write_sts_credentials
 
 
 logger = logging.getLogger(__name__)
+# Create some exception classes
+MalformedResponseWarning = type('MalformedResponseWarning', (Warning,), dict())
+STSWarning = type('STSWarning', (Warning,), dict())
 
 
 def get_credentials(bearer_token, id_token_dict, role_arn):
@@ -17,7 +20,8 @@ def get_credentials(bearer_token, id_token_dict, role_arn):
     :param bearer_token: OpenID Connect ID token provided by IdP
     :param id_token_dict: Parsed bearer_token
     :param role_arn: AWS IAM Role ARN of the role to assume
-    :return: dict : Dictionary of credential information
+    :return: dict : Dictionary of credential information or None if the
+        bearer_token can't be used to produce credentials
     """
     # Try to read the locally cached STS credentials
     credentials = read_sts_credentials(role_arn)
@@ -44,10 +48,22 @@ def get_credentials(bearer_token, id_token_dict, role_arn):
 
             # Call the STS API
             resp = requests.get(url=sts_url, params=parameters)
+            try:
+                root = ElementTree.fromstring(resp.content)
+            except ElementTree.ParseError as e:
+                raise MalformedResponseWarning('Unable to parse XML response to AssumeRoleWithWebIdentity call')
             if resp.status_code != requests.codes.ok:
-                if 'The requested DurationSeconds exceeds the MaxSessionDuration set for this role' in resp.text:
+                error = dict(
+                    [(x.tag.split('}', 1)[-1], x.text) for x in root.find(
+                        './sts:Error',
+                        {'sts': 'https://sts.amazonaws.com/doc/2011-06-15/'})])
+                logger.error(
+                    'AWS STS Call failed {status} {Type} {Code} : {Message}'.format(
+                        status=resp.status_code, **error))
+                if 'The requested DurationSeconds exceeds the MaxSessionDuration set for this role' in error['Message']:
                     continue
-                logger.error('AWS STS Call failed {} : {}'.format(resp.status_code, resp.text))
+                else:
+                    raise STSWarning(error['Type'], error['Code'], error['Message'])
             else:
                 logger.debug('Session established for {} seconds'.format(duration_seconds))
                 logger.debug('STS Call Response headers : {}'.format(resp.headers))
@@ -55,9 +71,8 @@ def get_credentials(bearer_token, id_token_dict, role_arn):
                 break
         else:
             # No break was encountered so none of the requests returned success
-            return None
+            raise STSWarning('Sender', 'NoAcceptableDuration', 'No DurationSeconds was found that did not exceed the MaxSessionDuration for the role')
 
-        root = ElementTree.fromstring(resp.content)
         # Create a dictionary of the children of
         # AssumeRoleWithWebIdentityResult/Credentials and their values
         credentials = dict([(x.tag.split('}', 1)[-1], x.text) for x in root.find(

--- a/mozilla_aws_cli/sts_conn.py
+++ b/mozilla_aws_cli/sts_conn.py
@@ -28,10 +28,11 @@ def get_credentials(bearer_token, id_token_dict, role_arn):
             if 'email' in id_token_dict
             else id_token_dict['sub'].split('|')[-1])
         sts_url = "https://sts.amazonaws.com/"
-        for duration_seconds in [43200, 3600]:  # 12 hours, 1 hour
+        for duration_seconds in [43200, 3600, 900]:  # 12 hours, 1 hour, 15 mins
             # First try to provision a session of 12 hours, then fall back to
             # 1 hour, the default max, if the 12 hour attempt fails. If that
-            # 1 hour duration also fails, then error out
+            # 1 hour duration also fails, then fall back to the minimum of 15
+            # minutes
             parameters = {
                 'Action': 'AssumeRoleWithWebIdentity',
                 'DurationSeconds': duration_seconds,

--- a/mozilla_aws_cli/sts_conn.py
+++ b/mozilla_aws_cli/sts_conn.py
@@ -60,7 +60,8 @@ def get_credentials(bearer_token, id_token_dict, role_arn):
                 logger.error(
                     'AWS STS Call failed {status} {Type} {Code} : {Message}'.format(
                         status=resp.status_code, **error))
-                if 'The requested DurationSeconds exceeds the MaxSessionDuration set for this role' in error['Message']:
+                if (error['Code'] == 'ValidationError'
+                        and error['Message'] == 'The requested DurationSeconds exceeds the MaxSessionDuration set for this role.'):
                     continue
                 else:
                     raise STSWarning(error['Type'], error['Code'], error['Message'])

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     name="mozilla_aws_cli",
     description="Command line tool to enable accessing AWS using federated single sign on",
     author="Mozilla Enterprise Information Security",
+    author_email="iam@discourse.mozilla.org",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Handle ExpiredTokenException correctly and restructure flow paths

* get_id_token was a method that did far more than getting an id token.
  This change explodes the functionality in that method into multiple
  methods.
  * `get_id_token`
  * `validate_id_token`
  * `get_role_map`
  * `exchange_token_for_credentials`
  * `print_output`
* Add checking for when AWS responds with ExpiredTokenException and
  initiate a new auth flow to fetch a new ID token.
  * This would come into play when we have a cached ID token that is
    older than the AWS undocumented max ID token validity of 1 day
  * This means that listener.py can now initiate a redirect for the user
    to start the auth flow over
  * This includes a new `state` value called "restart_auth" that triggers
    the redirect to the IdP to restart the auth flow
* Break out login path from 2 to 3 paths
  * Previously when going through the login method the user would either
    * Initiate an IdP auth flow if either the ID token was invalid or
      if the ID token was totally valid but the user hadn't asserted a
      role_arn
      * This meant that each time a user was running the tool and not
        passing a role_arn, there was an unnecessary IdP auth flow slowing
        things down (if there was a local cached valid ID token)
    * Skip the IdP auth flow if the user had both a cached ID token *and*
      had passed a role_arn as a command line argument
  * Now there are 3 paths
    * We have a cached ID token and the role was passed as an argument
    * We have a cached ID token but the role passed on the command line 
      wasn't valid. Show the role picker
    * Either the cached ID token was invalid or missing and we need
      to get a new one, or the user passed no role_arn on the command 
      line so we need to spawn the role picker
* Move token and id_token_dict from ephemeral variables into attributes of
  the Login class. This allows for persisting these values.
* Raise exceptions when STS call fails
* This emits clearer and more deterministic exceptions if the AWS STS call fails
* Add a 15 minute STS session length fallback
  * This will accomodate all possible MaxSession lengths that AWS could have
* Add detection of ID tokens that are older than what AWS allows
* Add author email to conform to the setup.py spec
* Add links to the docs of other projects in the same space as this one

Fixes #146
Fixes #141 