### PR TITLE
Add print_role_arn feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* Documentation warning about YADR and ZSH #140
+* Detection of ID Tokens that are older than AWS allows #150
+* 15 minute session duration fallback for IAM Roles which have under 1 hour max
+  session durations #150
+* Detection of expired ID tokens initiating a new auth flow #150
+* Faster login when using `-w` as now the cached ID Token is used if it's valid #150
+* Documentation on config file format
+* `print_role_arn` config setting
+* printing the role_arn to the console
+
+### Changed
+* Config file path changed from mozilla_aws_cli to maws #139
+* Config file parsing to use an intentional `maws` section
+
+### Fixed
+* Shutdown the CLI if the web interface gets closed #143 #128
+* Utils not using the global logger #147
+* Config file and config module settings not being merged #151
 
 ## [0.1.1] - 2019-11-21
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -17,22 +17,67 @@ Command line tool to enable accessing AWS using federated single sign on
 
 ## Instructions
 
-## Create a config
+Users can either configure Mozilla AWS CLI with a [python package](#creating-enterprise--organization-configuration)
+provided by their organization, or they can create a config file by hand.
 
-`cp config.yaml.inc config.yaml`
+## Create a config file
+
+The default files that configuration is fetched from are
+* `/etc/maws/config`
+* `~/.maws/config`
+
+where settings in `/etc/maws/config` are overridden by settings in `~/.maws/config`.
+
+Users can also assert which config file(s) to read from using the `-c` or `--config`
+command line arguments.
+
+These config files use the standard [INI file format](https://en.wikipedia.org/wiki/INI_file).
+
+The `config` file should contain a single section called `[maws]` and can
+contain the following settings.
+
+There are three *required* settings which must either be set in a [python package](#creating-enterprise--organization-configuration)
+provided by the organization or in the user's config file. Those required
+settings are
 
 * `well_known_url`: The
   [OpenID Connect Discovery Endpoint URL](https://openid.net/specs/openid-connect-discovery-1_0.html).
   ([Auth0](https://auth0.com/docs/protocols/oidc/openid-connect-discovery))
-* client_id: The Auth0 `client_id` generated when the Auth0
+* `client_id`: The Auth0 `client_id` generated when the Auth0
   [application](https://auth0.com/docs/applications) was created in the
   prerequisites
-* scope: A space delimited list of
+* `idtoken_for_roles_url` : The URL of the ID Token For Roles API. This URL
+  comes from the location that the user's organization has deployed the
+  [idtoken_for_roles](https://github.com/mozilla-iam/mozilla-aws-cli/tree/master/cloudformation)
+  API. This API lets a user exchange an ID token for a list of groups and roles
+  that they have rights to.
+
+Additional optional settings that can be configured in the config file are
+ 
+* `scope`: A space delimited list of
   [OpenID Connect Scopes](https://auth0.com/docs/scopes/current/oidc-scopes).
   For example `openid`. Avoid including a scope which passes too much data which
   will exceed the maximum AWS allowed size of the ID Token (for example at
   Mozilla we neglect to include the raw full group list which is included in the
   ID Token when the `https://sso.mozilla.com/claim/groups` scope is requested.
+* `output` : The output format for the tool to use. This must be one of the
+  following values
+  * `envvar` : A set of environment variables that load the temporary
+    credentials directly in to the environment without writing them to a file
+  * `shared` : A set of environment variables that reference a dedicated maws
+    AWS config file which is created
+  * `awscli` : A set of environment variables that reference the default AWS
+    CLI / AWS SDK config file which is written to
+* `print_role_arn` : Whether or not `maws` should display the AWS IAM Role ARN
+  on the command line. This can values like `yes`, `no`, `true`, `false`
+
+The resulting config would looks something like this
+```ini
+[maws]
+client_id = abcdefg
+idtoken_for_roles_url = https://roles-and-aliases.example/roles
+well_known_url = http://auth.example.com/.well-known/openid-configuration
+```
 
 ## Run the tool
 

--- a/mozilla_aws_cli/cli.py
+++ b/mozilla_aws_cli/cli.py
@@ -158,7 +158,6 @@ def main(batch, config, no_cache, output, role_arn, verbose, web_console):
     config["openid-configuration"] = requests.get(config["well_known_url"]).json()
     config["jwks"] = requests.get(config["openid-configuration"]["jwks_uri"]).json()
 
-    logger.debug("JWKS : {}".format(config["jwks"]))
     logger.debug("Config : {}".format(config))
 
     # Instantiate a login object, and begin login process

--- a/mozilla_aws_cli/cli.py
+++ b/mozilla_aws_cli/cli.py
@@ -83,6 +83,10 @@ def validate_config_file(ctx, param, filenames):
         config.add_section('maws')
 
     result = dict(config.items('maws'))
+    for boolean_field in ['print_role_arn']:
+        if boolean_field in result:
+            result[boolean_field] = config.getboolean('maws', boolean_field)
+
     if mozilla_aws_cli_config is not None:
         # Override the --config file contents with the mozilla_aws_cli_config
         # module contents

--- a/mozilla_aws_cli/cli.py
+++ b/mozilla_aws_cli/cli.py
@@ -153,11 +153,8 @@ def main(batch, config, no_cache, output, role_arn, verbose, web_console):
     if verbose:
         logger.setLevel(logging.DEBUG)
 
-    # The output setting "envvar" if not specified on the command line or in a
-    # config file
-    if output is None:
-        output = config.get("output", "envvar")
-
+    # Order of precedence : output, config["output"], "envvar"
+    config["output"] = output if output is not None else config.get("output", "envvar")
     config["openid-configuration"] = requests.get(config["well_known_url"]).json()
     config["jwks"] = requests.get(config["openid-configuration"]["jwks_uri"]).json()
 
@@ -173,7 +170,7 @@ def main(batch, config, no_cache, output, role_arn, verbose, web_console):
         idtoken_for_roles_url=config["idtoken_for_roles_url"],
         jwks=config["jwks"],
         openid_configuration=config["openid-configuration"],
-        output=output,
+        config=config,
         role_arn=role_arn,
         scope=config.get("scope"),
         token_endpoint=config["openid-configuration"]["token_endpoint"],

--- a/mozilla_aws_cli/login.py
+++ b/mozilla_aws_cli/login.py
@@ -56,7 +56,7 @@ class Login:
         idtoken_for_roles_url=None,
         jwks=None,
         openid_configuration=None,
-        output=None,
+        config=None,
         role_arn=None,
         scope="openid",
         token_endpoint="https://auth.mozilla.auth0.com/oauth/token",
@@ -78,7 +78,8 @@ class Login:
         self.idtoken_for_roles_url = idtoken_for_roles_url
         self.jwks = jwks
         self.openid_configuration = openid_configuration
-        self.output = output
+        self.config = {} if config is None else config
+        self.output = config.get("output", "envvar")
         self.role = None
         self.role_arn = role_arn
         self.role_map = None

--- a/mozilla_aws_cli/login.py
+++ b/mozilla_aws_cli/login.py
@@ -79,7 +79,7 @@ class Login:
         self.jwks = jwks
         self.openid_configuration = openid_configuration
         self.config = {} if config is None else config
-        self.output = config.get("output", "envvar")
+        self.output = self.config.get("output", "envvar")
         self.role = None
         self.role_arn = role_arn
         self.role_map = None

--- a/mozilla_aws_cli/static/index.js
+++ b/mozilla_aws_cli/static/index.js
@@ -117,7 +117,7 @@ const pollState = setInterval(async () => {
         // insert the image to log out of AWS and then redirect there once
         // it has loaded
         $("#aws-federation-logout").on("load error", () => {
-            window.location.replace = remoteState.value.awsFederationUrl;
+            document.location = remoteState.value.awsFederationUrl;
         }).attr("src", "https://signin.aws.amazon.com/oauth?Action=logout");
     } else if (remoteState.state === "invalid_id") {
         setMessage("Another federation session has been detected. Shutting down.");


### PR DESCRIPTION
* Update CHANGELOG with changes
* Add print_role_arn option
  * This allows the user to configure if they want to have the Role ARN shown on the command line (via stderr) or not.
  * Fixes #145
* Define config file section name
  * Previously we were using the ConfigParser's `defaults` behavior and expecting users to create a section in their `config` file called `[DEFAULT]`.
  * This change establishes an application specific section, `[maws]`. User's can still use `[DEFAULT]` if they wish.
  * By doing this we gain the ability to use all of the ConfigParser features the way it's expecting (like type coercion).
  * As nothing about the config file format was previously documented (including this `[DEFAULT]` convention, this commit contains docs explaining how the config file works.
* Clean up debug output
* Pass configuration into login object
* Revert Change to use window.location.replace to improve back button experience
  * This didn't work for some reason so reverting it
