### PR TITLE
Add new Group Role Map rebuild triggering mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ settings are
   comes from the location that the user's organization has deployed the
   [idtoken_for_roles](https://github.com/mozilla-iam/mozilla-aws-cli/tree/master/cloudformation)
   API. This API lets a user exchange an ID token for a list of groups and roles
-  that they have rights to.
+  that they have rights to. This URL should be the base URL of the API, ending
+  in `/`
 
 Additional optional settings that can be configured in the config file are
  

--- a/cloudformation/Makefile
+++ b/cloudformation/Makefile
@@ -52,7 +52,7 @@ deploy-idtoken-for-roles-dev:
 		 $(DEV_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME) \
 		 $(IDTOKEN_FOR_ROLES_STACK_NAME) \
 		 $(IDTOKEN_FOR_ROLES_CODE_STORAGE_S3_PREFIX) \
-		 "S3BucketName=$(DEV_S3_BUCKET_NAME) CustomDomainName=$(DEV_DOMAIN_NAME) DomainNameZone=$(DEV_DOMAIN_ZONE) CertificateArn=$(DEV_CERT_ARN) AllowedIssuer=$(DEV_ISSUER) AllowedAudience=$(DEV_CLIENT_ID)" \
+		 "S3BucketName=$(DEV_S3_BUCKET_NAME) CustomDomainName=$(DEV_DOMAIN_NAME) DomainNameZone=$(DEV_DOMAIN_ZONE) CertificateArn=$(DEV_CERT_ARN) AllowedIssuer=$(PROD_ISSUER) AllowedAudience=$(PROD_CLIENT_ID) AllowedMapBuilderSubPrefix=ad|Mozilla-LDAP|" \
 		 AliasesEndpointUrl
 
 .PHONE: deploy-idtoken-for-roles
@@ -63,7 +63,7 @@ deploy-idtoken-for-roles:
 		 $(PROD_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME) \
 		 $(IDTOKEN_FOR_ROLES_STACK_NAME) \
 		 $(IDTOKEN_FOR_ROLES_CODE_STORAGE_S3_PREFIX) \
-		 "S3BucketName=$(PROD_S3_BUCKET_NAME) CustomDomainName=$(PROD_DOMAIN_NAME) DomainNameZone=$(PROD_DOMAIN_ZONE) CertificateArn=$(PROD_CERT_ARN) AllowedIssuer=$(PROD_ISSUER) AllowedAudience=$(PROD_CLIENT_ID)" \
+		 "S3BucketName=$(PROD_S3_BUCKET_NAME) CustomDomainName=$(PROD_DOMAIN_NAME) DomainNameZone=$(PROD_DOMAIN_ZONE) CertificateArn=$(PROD_CERT_ARN) AllowedIssuer=$(PROD_ISSUER) AllowedAudience=$(PROD_CLIENT_ID) AllowedMapBuilderSubPrefix=ad|Mozilla-LDAP|" \
 		 AliasesEndpointUrl
 
 .PHONE: test-idtoken-for-roles

--- a/cloudformation/group_role_map_builder/functions/group_role_map_builder.py
+++ b/cloudformation/group_role_map_builder/functions/group_role_map_builder.py
@@ -8,7 +8,7 @@ import logging
 import boto3
 
 logger = logging.getLogger(__name__)
-logging.getLogger().setLevel(logging.INFO)
+logging.getLogger().setLevel(os.getenv('LOG_LEVEL', 'INFO'))
 logging.getLogger('boto3').propagate = False
 logging.getLogger('botocore').propagate = False
 logging.getLogger('urllib3').propagate = False

--- a/cloudformation/group_role_map_builder/group_role_map_builder.yaml
+++ b/cloudformation/group_role_map_builder/group_role_map_builder.yaml
@@ -137,6 +137,7 @@ Resources:
           VALID_AMRS: !Ref AmrClaims
       Handler: group_role_map_builder.lambda_handler
       Runtime: python3.7
+      ReservedConcurrentExecutions: 1
       Role: !GetAtt GroupRoleMapBuilderRole.Arn
       Tags:
         - Key: application
@@ -205,3 +206,13 @@ Outputs:
   GroupRoleMapConsumerUserSecretAccessKey:
     Description: The AWS API Access Key Secret Key of the GroupRoleMapConsumerUser
     Value: !GetAtt GroupRoleMapConsumerAccessKey.SecretAccessKey
+  GroupRoleMapBuilderFunctionName:
+    Description: Name of the Group Role Map Builder AWS Lambda function
+    Value: !Ref GroupRoleMapBuilderFunction
+    Export:
+      Name: GroupRoleMapBuilderFunctionName
+  GroupRoleMapBuilderFunctionArn:
+    Description: ARN of the Group Role Map Builder AWS Lambda function
+    Value: !GetAtt GroupRoleMapBuilderFunction.Arn
+    Export:
+      Name: GroupRoleMapBuilderFunctionArn

--- a/cloudformation/idtoken_for_roles/functions/idtoken_for_roles.py
+++ b/cloudformation/idtoken_for_roles/functions/idtoken_for_roles.py
@@ -1,7 +1,9 @@
-from typing import Dict
+from typing import Dict, Tuple, Optional
 import json
 import os
 import logging
+import traceback
+from datetime import tzinfo, timedelta, datetime
 import boto3
 from jose import jwt, exceptions
 
@@ -17,16 +19,69 @@ S3_FILE_PATH_GROUP_ROLE_MAP = os.getenv(
     'S3_FILE_PATH_GROUP_ROLE_MAP', 'access-group-iam-role-map.json')
 S3_FILE_PATH_ALIAS_MAP = os.getenv(
     'S3_FILE_PATH_ALIAS_MAP', 'account-aliases.json')
+ALLOWED_MAP_BUILDER_SUB_PREFIX = os.getenv(
+    'ALLOWED_MAP_BUILDER_SUB_PREFIX', False)
+GROUP_ROLE_MAP_BUILDER_FUNCTION_NAME = os.getenv(
+    'GROUP_ROLE_MAP_BUILDER_FUNCTION_NAME')
 
+METHOD_NOT_ALLOWED = {
+    'headers': {'Content-Type': 'text/html'},
+    'statusCode': 405,
+    'body': '405 Method Not Allowed'}
+
+ZERO = timedelta(0)
+
+
+class UTC(tzinfo):
+    def utcoffset(self, dt):
+        return ZERO
+    def tzname(self, dt):
+        return "UTC"
+    def dst(self, dt):
+        return ZERO
+
+utc = UTC()
 
 SimpleDict = Dict[str, str]
 DictOfLists = Dict[str, list]
+TokenValidationError = type('TokenValidationError', (ValueError,), dict())
+
+
+def validate_token(token, key):
+    required_env_variables = {'ALLOWED_ISSUER', 'ALLOWED_AUDIENCE'}
+    if not required_env_variables.issubset(set(os.environ)):
+        missing_env_variables = (
+                required_env_variables -
+                required_env_variables.intersection(set(os.environ)))
+        raise TokenValidationError(
+            'Environment variables {} not set in idtoken_for_roles. Contact '
+            'the IAM administrators.'.format(missing_env_variables))
+    try:
+        id_token = jwt.decode(
+            token=token,
+            key=key,
+            audience=os.getenv('ALLOWED_AUDIENCE'),
+            issuer=os.getenv('ALLOWED_ISSUER'),
+        )
+    except exceptions.ExpiredSignatureError as e:
+        logger.error('Expired JWT signature : {}'.format(e))
+        raise TokenValidationError('Expired JWT signature')
+    except exceptions.JWTClaimsError as e:
+        logger.error('Invalid claims in ID Token (allowed audience {} allowed issuer {}) : {}'.format(os.getenv('ALLOWED_AUDIENCE'), os.getenv('ALLOWED_ISSUER'), e))
+        raise TokenValidationError('Invalid claims in ID Token')
+    except exceptions.JWTError as e:
+        logger.error('Invalid JWT signature : {}'.format(e))
+        raise TokenValidationError('Invalid JWT signature')
+    if 'amr' not in id_token:
+        logger.error('amr claim missing from ID Token : {}'.format(id_token))
+        raise TokenValidationError('amr claim missing from ID Token')
+    return id_token
 
 
 def get_s3_file(
     s3_bucket: str,
     s3_key: str,
-) -> DictOfLists:
+) -> Tuple[Optional[datetime], DictOfLists]:
     """Fetch a map from S3
 
     :param str s3_bucket: The name of the S3 bucket to store the file in
@@ -41,63 +96,43 @@ def get_s3_file(
         response = client.get_object(**kwargs)
     except client.exceptions.ClientError as e:
         if e.response['Error']['Code'] == 'NoSuchKey':
-            return dict()
+            return None, dict()
         else:
             raise
-    return json.load(response['Body'])
+    return response['LastModified'], json.load(response['Body'])
 
 
 def get_roles_and_aliases(token, key, cache):
     global group_role_map
     global account_alias_map
 
-    required_env_variables = {'ALLOWED_ISSUER', 'ALLOWED_AUDIENCE'}
-    if not required_env_variables.issubset(set(os.environ)):
-        missing_env_variables = (
-                required_env_variables -
-                required_env_variables.intersection(set(os.environ)))
-        error_message = (
-            'Environment variables {} not set in idtoken_for_roles. Contact '
-            'the IAM administrators.')
-        return {'error': error_message.format(missing_env_variables)}
     try:
-        id_token = jwt.decode(
-            token=token,
-            key=key,
-            audience=os.getenv('ALLOWED_AUDIENCE'),
-            issuer=os.getenv('ALLOWED_ISSUER'),
-        )
-    except exceptions.ExpiredSignatureError as e:
-        return {'error': 'Expired JWT signature : {}'.format(e)}
-    except exceptions.JWTClaimsError as e:
-        return {'error': 'Invalid claims in ID Token : {}'.format(e)}
-    except exceptions.JWTError as e:
-        return {'error': 'Invalid JWT signature : {}'.format(e)}
-    if 'amr' not in id_token:
-        return {'error': 'amr claim missing from ID Token'}
+        id_token = validate_token(token, key)
+    except TokenValidationError as e:
+        return {'error': str(e)}
     if (not cache) or ('group_role_map' not in globals()):
         logger.debug(
             'Group Role Map was not found in globals, refetching from S3')
-        group_role_map = get_s3_file(
+        _, group_role_map = get_s3_file(
             S3_BUCKET_NAME, S3_FILE_PATH_GROUP_ROLE_MAP)
     if (not cache) or ('account_alias_map' not in globals()):
         logger.debug(
             'Account Alias Map was not found in globals, refetching from S3')
-        account_alias_map = get_s3_file(S3_BUCKET_NAME, S3_FILE_PATH_ALIAS_MAP)
+        _, account_alias_map = get_s3_file(
+            S3_BUCKET_NAME, S3_FILE_PATH_ALIAS_MAP)
     roles = set()
     aliases = {}
     for group, mapped_roles in group_role_map.items():
-        if group in id_token.get('amr', []):
+        if group in id_token['amr']:
             for role in mapped_roles:
                 aws_account_id = role.split(':')[4]
                 if (aws_account_id in account_alias_map
                         and aws_account_id not in aliases):
-                    aliases[aws_account_id] = account_alias_map[
-                        aws_account_id]
+                    aliases[aws_account_id] = account_alias_map[aws_account_id]
             roles.update(mapped_roles)
         else:
             logger.debug('Group {} not in amr {}'.format(
-                group, id_token.get('amr')))
+                group, id_token['amr']))
     return {'roles': list(roles), 'aliases': aliases}
 
 
@@ -106,17 +141,96 @@ def get_aliases(cache):
     if (not cache) or ('account_alias_map' not in globals()):
         logger.debug(
             'Account Alias Map was not found in globals, refetching from S3')
-        account_alias_map = get_s3_file(S3_BUCKET_NAME, S3_FILE_PATH_ALIAS_MAP)
+        _, account_alias_map = get_s3_file(
+            S3_BUCKET_NAME, S3_FILE_PATH_ALIAS_MAP)
     return account_alias_map
+
+
+def initiate_group_role_map_rebuild(token, key):
+    try:
+        id_token = validate_token(token, key)
+    except TokenValidationError as e:
+        return {'error': str(e)}
+    if not ALLOWED_MAP_BUILDER_SUB_PREFIX:
+        return {'error': 'ALLOWED_MAP_BUILDER_SUB_PREFIX is unset'}
+    if not id_token.get('sub', '').startswith(ALLOWED_MAP_BUILDER_SUB_PREFIX):
+        return {'error': 'User is not permitted'}
+    if GROUP_ROLE_MAP_BUILDER_FUNCTION_NAME is None:
+        return {'error': 'GROUP_ROLE_MAP_BUILDER_FUNCTION_NAME is unset'}
+    group_role_map_last_modified, group_role_map = get_s3_file(
+        S3_BUCKET_NAME, S3_FILE_PATH_GROUP_ROLE_MAP)
+    logger.debug('datetime.now(utc) is {} and group_role_map_last_modified is {}'.format(datetime.now(utc), group_role_map_last_modified))
+    group_role_map_age = datetime.now(utc) - group_role_map_last_modified
+    # TODO : Here's the problem. This comparison is between the last time the file changed and now
+    # and the file isn't updated if nothing changed
+    # so this doesn't stop someone from invoking over and over again
+    # we need make group role map buider touch a file or something indicating that a scan has been done
+    # despite the fact that the json map hasn't changed
+    # or persist this state here in idtokenforroles some other way
+    seconds_until_next_allowed_rebuild = max(
+        0, (60 * 5) - int(group_role_map_age.total_seconds()))
+    if seconds_until_next_allowed_rebuild > 0:
+        return {
+            'error': 'It has been less than 5 minutes since the last rebuild. '
+                     'You must wait another {} seconds before '
+                     'rebuilding.'.format(seconds_until_next_allowed_rebuild)}
+    client = boto3.client('lambda')
+    response = client.invoke(
+        FunctionName=GROUP_ROLE_MAP_BUILDER_FUNCTION_NAME,
+        InvocationType='Event',
+    )
+    logger.info('User {} initiated a group role map rebuild'.format(
+        id_token.get('sub')))
+    if response.get('FunctionError'):
+        logger.error('group role map rebuild invocation returned {}'.format(
+            response.get('FunctionError')
+        ))
+    return {'status': 'success : {}'.format(response.get('StatusCode'))}
 
 
 def lambda_handler(event, context):
     logger.debug("event type is {} and event is {}".format(type(event), event))
+    try:
+        params = (event['queryStringParameters']
+                  if event['queryStringParameters'] is not None else {})
+        body = event.get('body')
+        payload = json.loads(body) if body is not None else {}
+        if event.get('path') == '/account-aliases':
+            if event.get('httpMethod') != 'GET':
+                return METHOD_NOT_ALLOWED
+            return {
+                'headers': {'Content-Type': 'application/json'},
+                'statusCode': 200,
+                'body': json.dumps(get_aliases(params.get('cache', True)))}
+        elif event.get('path') == '/roles':
+            if event.get('httpMethod') != 'POST':
+                return METHOD_NOT_ALLOWED
 
-    token = event.get('token')
-    key = event.get('key')
-    cache = event.get('cache', True)
-    if token and key:
-        return get_roles_and_aliases(token, key, cache)
-    else:
-        return get_aliases(cache)
+            return {
+                'headers': {'Content-Type': 'application/json'},
+                'statusCode': 200,
+                'body': json.dumps(get_roles_and_aliases(
+                    payload.get('token'),
+                    payload.get('key'),
+                    payload.get('cache', True)))}
+        elif event.get('path') == '/rebuild-group-role-map':
+            if event.get('httpMethod') != 'POST':
+                return METHOD_NOT_ALLOWED
+            return {
+                'headers': {'Content-Type': 'application/json'},
+                'statusCode': 200,
+                'body': json.dumps(initiate_group_role_map_rebuild(
+                    payload.get('token'),
+                    payload.get('key')))}
+        else:
+            return {
+                'headers': {'Content-Type': 'text/html'},
+                'statusCode': 404,
+                'body': '404 Not Found'}
+    except Exception as e:
+        logger.error(str(e))
+        logger.error(traceback.format_exc())
+        return {
+            'headers': {'Content-Type': 'text/html'},
+            'statusCode': 500,
+            'body': 'Error'}

--- a/cloudformation/idtoken_for_roles/idtoken_for_roles.yaml
+++ b/cloudformation/idtoken_for_roles/idtoken_for_roles.yaml
@@ -15,11 +15,10 @@ Metadata:
       Parameters:
       - AllowedIssuer
       - AllowedAudience
+      - AllowedMapBuilderSubPrefix
     - Label:
         default: API
       Parameters:
-      - RolesPathPrefix
-      - AliasesPathPrefix
       - CustomDomainName
       - DomainNameZone
       - CertificateArn
@@ -34,10 +33,8 @@ Metadata:
         default: Allowed OIDC Issuer
       AllowedAudience:
         default: Allowed OIDC Audience
-      RolesPathPrefix:
-        default: API Path Prefix for the Group Role Map endpoint
-      AliasesPathPrefix:
-        default: API Path Prefix for the AWS Account Alias Map endpoint
+      AllowedMapBuilderSubPrefix:
+        default: The prefix of the sub OIDC claim that is required for premission to initiate a group role map rebuild
       CustomDomainName:
         default: Custom DNS Domain Name
       DomainNameZone:
@@ -62,14 +59,9 @@ Parameters:
   AllowedAudience:
     Type: String
     Description: OIDC Audience. For Mozilla this is the Auth0 Client ID
-  RolesPathPrefix:
+  AllowedMapBuilderSubPrefix:
     Type: String
-    Description: The URL path prefix to POST ID tokens to and get back roles
-    Default: roles
-  AliasesPathPrefix:
-    Type: String
-    Description: The URL path prefix to GET account aliases from
-    Default: account-aliases
+    Description: The prefix of the sub OIDC claim that is required for premission to initiate a group role map rebuild
   CustomDomainName:
     Type: String
     Description: The custom domain name to use for the API
@@ -128,6 +120,15 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource: !Join ['', ['arn:aws:s3:::', !Ref 'S3BucketName']]
+        - PolicyName: AllowInvokeGroupRoleMapBuilder
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                - lambda:Invoke*
+                Resource:
+                  - !ImportValue GroupRoleMapBuilderFunctionArn
   IdtokenForRolesFunction:
     Type: AWS::Lambda::Function
     Properties:
@@ -140,6 +141,9 @@ Resources:
           S3_FILE_PATH_ALIAS_MAP: !Ref AccountAliasesS3FilePath
           ALLOWED_ISSUER: !Ref AllowedIssuer
           ALLOWED_AUDIENCE: !Ref AllowedAudience
+          LOG_LEVEL: INFO
+          ALLOWED_MAP_BUILDER_SUB_PREFIX: !Ref AllowedMapBuilderSubPrefix
+          GROUP_ROLE_MAP_BUILDER_FUNCTION_NAME: !ImportValue GroupRoleMapBuilderFunctionName
       Handler: idtoken_for_roles.lambda_handler
       Runtime: python3.7
       Role: !GetAtt IdtokenForRolesFunctionRole.Arn
@@ -224,7 +228,8 @@ Resources:
   IdtokenForRolesApiDeployment:
     Type: AWS::ApiGateway::Deployment
     DependsOn:
-      - IdtokenForRoleRolesRequest
+      - IdtokenForRoleRolesGetRequest
+      - IdtokenForRoleRolesPostRequest
     Properties:
       RestApiId: !Ref IdtokenForRolesApi
       StageName: DummyStage
@@ -241,62 +246,44 @@ Resources:
     Properties:
       RestApiId: !Ref IdtokenForRolesApi
       ParentId: !GetAtt IdtokenForRolesApi.RootResourceId
-      PathPart: !Ref RolesPathPrefix
-  AliasesResource:
-    Type: AWS::ApiGateway::Resource
-    Properties:
-      RestApiId: !Ref IdtokenForRolesApi
-      ParentId: !GetAtt IdtokenForRolesApi.RootResourceId
-      PathPart: !Ref AliasesPathPrefix
-  IdtokenForRoleRolesRequest:
-    DependsOn: IdtokenForRolesLambdaPermission
-    Type: AWS::ApiGateway::Method
-    Properties:
-      AuthorizationType: NONE
-      HttpMethod: POST
-      Integration:
-        Type: AWS
-        IntegrationHttpMethod: POST
-        Uri: !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', ':lambda:path/2015-03-31/functions/', !GetAtt 'IdtokenForRolesFunction.Arn', '/invocations' ] ]
-        IntegrationResponses:
-          - StatusCode: '200'
-#        RequestTemplates:
-#          application/json: '{"name": "$input.params(\'name\')"}'
-#      RequestParameters:
-#        method.request.querystring.name: false
-      ResourceId: !Ref IdtokenForRolesResource
-      RestApiId: !Ref IdtokenForRolesApi
-      MethodResponses:
-        - StatusCode: '200'
-          # TODO Add a 403 mapping for when the idtoken is invalid
-  AliasesRequest:
+      PathPart: '{proxy+}'
+  IdtokenForRoleRolesGetRequest:
     DependsOn: IdtokenForRolesLambdaPermission
     Type: AWS::ApiGateway::Method
     Properties:
       AuthorizationType: NONE
       HttpMethod: GET
       Integration:
-        Type: AWS
+        Type: AWS_PROXY
+        # https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#set-up-lambda-proxy-integration-using-cli
+        # "For Lambda integrations, you must use the HTTP method of POST for the
+        # integration request, according to the specification of the Lambda service
+        # action for function invocations."
         IntegrationHttpMethod: POST
         Uri: !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', ':lambda:path/2015-03-31/functions/', !GetAtt 'IdtokenForRolesFunction.Arn', '/invocations' ] ]
-        IntegrationResponses:
-          - StatusCode: '200'
-      ResourceId: !Ref AliasesResource
+      ResourceId: !Ref IdtokenForRolesResource
       RestApiId: !Ref IdtokenForRolesApi
-      MethodResponses:
-        - StatusCode: '200'
+  IdtokenForRoleRolesPostRequest:
+    DependsOn: IdtokenForRolesLambdaPermission
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+      HttpMethod: POST
+      Integration:
+        Type: AWS_PROXY
+        # https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#set-up-lambda-proxy-integration-using-cli
+        # "For Lambda integrations, you must use the HTTP method of POST for the
+        # integration request, according to the specification of the Lambda service
+        # action for function invocations."
+        IntegrationHttpMethod: POST
+        Uri: !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', ':lambda:path/2015-03-31/functions/', !GetAtt 'IdtokenForRolesFunction.Arn', '/invocations' ] ]
+      ResourceId: !Ref IdtokenForRolesResource
+      RestApiId: !Ref IdtokenForRolesApi
 Outputs:
-  RolesEndpointUrl:
-    Description: The URL of the token for roles API Endpoint
+  EndpointUrl:
+    Description: The URL of the ID token for roles API Endpoint
     Value:
       Fn::If:
         - UseCustomDomainName
-        - !Join [ '', [ 'https://', !Ref 'CustomDomainName', '/', !Ref 'RolesPathPrefix'] ]
-        - !Join [ '', [ 'https://', !Ref 'IdtokenForRolesApi', '.execute-api.', !Ref 'AWS::Region', '.amazonaws.com/', !Ref 'IdtokenForRolesApiStage', '/', !Ref 'RolesPathPrefix' ] ]
-  AliasesEndpointUrl:
-    Description: The URL of the token for aliases API Endpoint
-    Value:
-      Fn::If:
-        - UseCustomDomainName
-        - !Join [ '', [ 'https://', !Ref 'CustomDomainName', '/', !Ref 'AliasesPathPrefix'] ]
-        - !Join [ '', [ 'https://', !Ref 'IdtokenForRolesApi', '.execute-api.', !Ref 'AWS::Region', '.amazonaws.com/', !Ref 'IdtokenForRolesApiStage', '/', !Ref 'AliasesPathPrefix' ] ]
+        - !Join [ '', [ 'https://', !Ref 'CustomDomainName', '/'] ]
+        - !Join [ '', [ 'https://', !Ref 'IdtokenForRolesApi', '.execute-api.', !Ref 'AWS::Region', '.amazonaws.com/', !Ref 'IdtokenForRolesApiStage', '/' ] ]


### PR DESCRIPTION
* Change ID token for role to use API Gateway proxy mode and pass all requests onto the Lambda function
  * Change how ID token for role decides what action to take. Previously it used the HTTP method. Now it uses the URL path
* Add new Group Role Map rebuild triggering mechanism
  * Add new AllowedMapBuilderSubPrefix setting to limit who can trigger map rebuilds
  * Limit concurrent executions of the group role map builder to prevent multiple simultaneous builds
  * Export the group role map builder lambda function name and ARN to CloudFormation for consumption by the ID token for role API
* Add new functionality to ID token for role allowing an authenticated user with a sub beginning with the ALLOWED_MAP_BUILDER_SUB_PREFIX to trigger a group role map rebuild
  * Grant the ID token for role API rights to invoke the group role map builder