### PR TITLE
Update for v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0] - 2019-12-06
 ### Added
 * Documentation warning about YADR and ZSH #140
 * Detection of ID Tokens that are older than AWS allows #150
@@ -12,18 +14,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   session durations #150
 * Detection of expired ID tokens initiating a new auth flow #150
 * Faster login when using `-w` as now the cached ID Token is used if it's valid #150
-* Documentation on config file format
-* `print_role_arn` config setting
-* printing the role_arn to the console
+* Documentation on config file format #154
+* `print_role_arn` config setting #154
+* Printing the role_arn to the console #154
+* Option to set the AWS profile name in shared and awscli output #132 #157
+* Add new Group Role Map rebuild triggering mechanism #158
 
 ### Changed
 * Config file path changed from mozilla_aws_cli to maws #139
-* Config file parsing to use an intentional `maws` section
+* Config file parsing to use an intentional `maws` section #154
+* Changes the expected `idtoken_for_roles_url` URL format to expect the root URL
+  instead of the URL ending in `/roles`
+  * This change requires that config files use the base URL now and that any
+    installed mozilla-aws-cli python packages providing `mozilla_aws_config`
+    set the base URL for `idtoken_for_roles_url`
 
 ### Fixed
-* Shutdown the CLI if the web interface gets closed #143 #128
+* If the web interface gets closed, making sure to shutdown the CLI #143 #128
 * Utils not using the global logger #147
 * Config file and config module settings not being merged #151
+* When specifying role with -r that's not available, erroring out #127 #156
 
 ## [0.1.1] - 2019-11-21
 ### Fixed
@@ -43,7 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Initial release of the mozilla-aws-cli tool
 
-[Unreleased]: https://github.com/mozilla-iam/mozilla-aws-cli/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/mozilla-iam/mozilla-aws-cli/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/mozilla-iam/mozilla-aws-cli/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/mozilla-iam/mozilla-aws-cli/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/mozilla-iam/mozilla-aws-cli/compare/v0.0.2...v0.1.0
 [0.0.2]: https://github.com/mozilla-iam/mozilla-aws-cli/releases/tag/v0.0.2

--- a/mozilla_aws_cli/login.py
+++ b/mozilla_aws_cli/login.py
@@ -317,9 +317,9 @@ class Login:
     def get_role_map(self):
         # get the role map, either from cache or from the endpoint
         self.state = "getting_role_map"
-
+        url = "{}roles".format(self.idtoken_for_roles_url)
         self.role_map = get_roles_and_aliases(
-            endpoint=self.idtoken_for_roles_url,
+            endpoint=url,
             token=self.token["id_token"],
             key=self.jwks
         )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ requirements = [
     "Click>=6.0",
     "flask>=1.0.2",
     "requests>=2.20.1",
-    "console-menu",
     "python-jose",
 ]
 setup_requirements = ["pytest-runner"]

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,6 @@ setup(
     tests_require=test_requirements,
     extras_require=extras,
     url="https://github.com/mozilla-iam/mozilla-aws-cli",
-    version="0.1.1",
+    version="0.2.0",
     zip_safe=False,
 )


### PR DESCRIPTION
* Change format of idtoken_for_roles_url
  * This changes the expectation of a configured idtoken_for_roles_url from
       https://example.com/roles
  * to
      https://example.com/
* Remove no longer used console-menu requirement
