### PR TITLE
Fix handling STS AccessDenied responses

### DIFF
--- a/mozilla_aws_cli/cli.py
+++ b/mozilla_aws_cli/cli.py
@@ -26,7 +26,10 @@ else:
     import ConfigParser as configparser
 
 
-logging.basicConfig()
+logging.basicConfig(
+    format='%(asctime)s %(levelname)-8s [%(filename)s:%(lineno)d] '
+           '%(message)s',
+    datefmt='%Y-%m-%d:%H:%M:%S')
 logger = logging.getLogger()
 logger.setLevel(logging.ERROR)
 logging.getLogger('urllib3').propagate = False

--- a/mozilla_aws_cli/login.py
+++ b/mozilla_aws_cli/login.py
@@ -26,7 +26,8 @@ from .utils import (
     base64_without_padding,
     exit_sigint,
     generate_challenge,
-    role_arn_to_profile_name
+    role_arn_to_profile_name,
+    STSWarning
 )
 
 try:
@@ -44,7 +45,6 @@ ENV_VARIABLE_NAME_MAP = {
     "SecretAccessKey": "AWS_SECRET_ACCESS_KEY",
     "SessionToken": "AWS_SESSION_TOKEN",
 }
-STSWarning = type('STSWarning', (Warning,), dict())
 
 
 class Login:
@@ -184,10 +184,12 @@ class Login:
                     if e.args[1] == 'ExpiredTokenException':
                         logger.debug('Looks like that cached ID token is expired, setting self.token to None')
                         self.token = None
-                    else:
-                        raise
                 except requests.exceptions.ConnectionError as e:
                     self.exit("Unable to contact AWS : {}".format(e))
+                if self.batch and self.role_arn is None:
+                    self.exit(
+                        'Unable to fetch AWS STS credentials with ID '
+                        'token. Exiting due to batch mode.')
                 if self.token is not None and self.role_arn is not None:
                     self.print_output()
 
@@ -345,49 +347,41 @@ class Login:
 
 
     def exchange_token_for_credentials(self):
-        # TODO: Consider whether this needs to loop forever
-        while self.credentials is None:
-            # If we don't have a role ARN on the command line, we need to show
-            # the role picker
-            if self.role_arn is None and not self.batch:
-                self.state = "role_picker"
+        # If we don't have a role ARN on the command line, we need to show
+        # the role picker
+        if self.role_arn is None and not self.batch:
+            self.state = "role_picker"
 
-                # Wait for the POST to /api/roles
-                while not self.role_arn:
-                    self.sleep(.05)
+            # Wait for the POST to /api/roles
+            while not self.role_arn:
+                self.sleep(.05)
 
-            # Use the cached credentials or retrieve them from STS
-            self.state = "getting_sts_credentials"
-            try:
-                self.credentials = sts_conn.get_credentials(
-                    self.token["id_token"],
-                    self.id_token_dict,
-                    role_arn=self.role_arn
-                )
-            except STSWarning as e:
-                if e.args[1] == 'AccessDenied':
-                    # Not authorized to perform sts:AssumeRoleWithWebIdentity
-                    # Either that role doesn't exist or it exists but doesn't
-                    # permit the user because of the conditions
-                    logger.error(
-                        'Unable to assume role {}. Please select a different '
-                        'role.'.format(self.role_arn))
-                    self.role_map.get("roles", []).remove(self.role_arn)
-                    self.role_arn = None
-                    if len(self.role_map.get("roles", [])) <= 1:
-                        self.exit(
-                            "Sorry, no valid roles available. Shutting down.")
-                elif e.args[1] == 'ExpiredTokenException':
-                    # The ID token is expired
-                    raise
-                else:
-                    raise
-
-            if self.batch:
-                break
-
-        logger.debug(self.credentials)
-        logger.debug("ID token : {}".format(self.token["id_token"]))
+        # Use the cached credentials or retrieve them from STS
+        self.state = "getting_sts_credentials"
+        try:
+            self.credentials = sts_conn.get_credentials(
+                self.token["id_token"],
+                self.id_token_dict,
+                role_arn=self.role_arn
+            )
+            logger.debug(self.credentials)
+            logger.debug("ID token : {}".format(self.token["id_token"]))
+        except STSWarning as e:
+            if e.args[1] == 'AccessDenied':
+                # Not authorized to perform sts:AssumeRoleWithWebIdentity
+                # Either that role doesn't exist or it exists but doesn't
+                # permit the user because of the conditions
+                logger.debug('Unable to assume role {}'.format(self.role_arn))
+                self.role_map.get("roles", []).remove(self.role_arn)
+                self.role_arn = None
+                if len(self.role_map.get("roles", [])) <= 1:
+                    self.exit(
+                        "Sorry, no valid roles available. Shutting down.")
+            elif e.args[1] == 'ExpiredTokenException':
+                # The ID token is expired
+                raise
+            else:
+                raise
 
 
     def print_output(self):

--- a/mozilla_aws_cli/role_picker.py
+++ b/mozilla_aws_cli/role_picker.py
@@ -22,7 +22,7 @@ def output_set_env_vars(var_map):
 def get_roles_and_aliases(endpoint, token, key, cache=True):
     role_map = read_group_role_map(endpoint)
 
-    if role_map is None:
+    if role_map is None or not cache:
         headers = {"Content-Type": "application/json"}
         body = {
             "token": token,

--- a/mozilla_aws_cli/sts_conn.py
+++ b/mozilla_aws_cli/sts_conn.py
@@ -6,12 +6,12 @@ from xml.etree import ElementTree
 import requests
 
 from .cache import read_sts_credentials, write_sts_credentials
+from .utils import STSWarning
 
 
 logger = logging.getLogger(__name__)
 # Create some exception classes
 MalformedResponseWarning = type('MalformedResponseWarning', (Warning,), dict())
-STSWarning = type('STSWarning', (Warning,), dict())
 
 
 def get_credentials(bearer_token, id_token_dict, role_arn):
@@ -57,7 +57,7 @@ def get_credentials(bearer_token, id_token_dict, role_arn):
                     [(x.tag.split('}', 1)[-1], x.text) for x in root.find(
                         './sts:Error',
                         {'sts': 'https://sts.amazonaws.com/doc/2011-06-15/'})])
-                logger.error(
+                logger.debug(
                     'AWS STS Call failed {status} {Type} {Code} : {Message}'.format(
                         status=resp.status_code, **error))
                 if (error['Code'] == 'ValidationError'

--- a/mozilla_aws_cli/utils.py
+++ b/mozilla_aws_cli/utils.py
@@ -7,6 +7,7 @@ import sys
 
 
 logger = logging.getLogger(__name__)
+STSWarning = type('STSWarning', (Warning,), dict())
 
 
 def base64_without_padding(data):


### PR DESCRIPTION
Fix handling STS AccessDenied responses

* Consolidate the STSWarning class in utils because otherwise each module's STSWarning is a distinct class
* Change login.exchange_token_for_credentials so it no longer loops, retrying t get credentials.
  * This looping has been moved up to listener.py where we want to loop (when we have a role picker)
* Fix when a role is passed as a CLI argument but AWS responds with AccessDenied
  * Now, if this happens, the CLI spawns the role picker to select a different role
  * Unless --batch is specified in which case the CLI just exits

Update cached role_map if AWS gives AccessDenied

AWS returning AccessDenied is a good indicator that our cached role map isn't accurate.
This makes the tool refresh the role map if an AccessDenied is encountered
This also reimplements #156 differently.
* We shouldn't test if the role_arn is present in the role_map in a function called `get_role_map`
* We don't want to check if the role_arn is present in cases where we merely want to refresh the role map

This also sends a message to the console stderr if the user provides an invalid role ARN as
a command line argument, before spawning the role picker.
* Ideally this message would be shown in the role picker but it looks like it would take some
  heavy lifting to enable triggering a `setMessage` in index.js from the beginning of a
  redirect flow such that it shows up after auth completes and the user is at the role picker

