### PR TITLE
Remove synchronous blocking frontend backend interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,3 +385,4 @@ mozilla-aws-cli-yoyodyne/
 * https://github.com/prolane/samltoawsstskeys
 * https://github.com/physera/onelogin-aws-cli
 * https://github.com/kxseven/axe/blob/master/bin/subcommands/axe-token-krb5formauth-create
+* https://github.com/openstandia/aws-cli-oidc

--- a/mozilla_aws_cli/cli.py
+++ b/mozilla_aws_cli/cli.py
@@ -179,6 +179,8 @@ def main(batch, config, cache, output,
         print("Unable to contact identity provider {} : {}".format(
             config["well_known_url"], e), file=sys.stderr)
         return False
+    if batch and role_arn is None:
+        raise click.exceptions.UsageError('You must pass a role_arn in batch mode')
 
     logger.debug("Config : {}".format(config))
 

--- a/mozilla_aws_cli/static/index.js
+++ b/mozilla_aws_cli/static/index.js
@@ -7,6 +7,8 @@ const state = {
     getStateCount: 0,
     lastRole: undefined,
     roleRetrievalCount: 0,
+    backendInProgress: false,
+    heartbeatRunning: false
 };
 
 const setMessage = (message) => {
@@ -68,7 +70,27 @@ const shutdown = async () => {
 };
 
 const pollState = setInterval(async () => {
+    if (! state.backendInProgress) {
+        state.backendInProgress = true;
+    } else {
+        // The previous pollState async has not yet finished, skipping this async execution
+        return false;
+    }
     const id = new URLSearchParams(window.location.search).get("state").split("-")[0];
+    if (! state.heartbeatRunning) {
+        state.heartbeatRunning = true;
+        fetch(`/api/heartbeat?id=${id}`, {
+            method: "GET"
+        }).then((response) => {
+            return response.json();
+        }).then((responseJson) => {
+            if (responseJson.result !== "running") {
+                state.heartbeatRunning = false;
+            }
+        });
+
+    }
+
     let response = await fetch(`/api/state?id=${id}`, {
         method: "GET"
     });
@@ -98,13 +120,8 @@ const pollState = setInterval(async () => {
                 "Content-Type": "application/json",
             }
         });
+        await r.json();
     } else if (remoteState.state === "role_picker") {
-        if (state.roleRetrievalCount > 0) {
-            setMessage(`Invalid role ${state.lastRole}. Please pick a different role:`)
-        } else {
-            setMessage("Please select a role:");
-        }
-
         response = await fetch("/api/roles", {
             method: "GET",
             cache: "no-cache"
@@ -112,6 +129,11 @@ const pollState = setInterval(async () => {
 
         // show the roles
         const roles = await response.json();
+        if (state.roleRetrievalCount > 0) {
+            setMessage(`Invalid role ${state.lastRole}. Please pick a different role:`)
+        } else {
+            setMessage("Please select a role:");
+        }
         showRoles(roles);
     } else if (remoteState.state === "restart_auth") {
         setMessage("Redirecting to identity provider...");
@@ -129,7 +151,7 @@ const pollState = setInterval(async () => {
         setMessage("Another federation session has been detected. Shutting down.");
         clearInternal(pollState);
     } else if (remoteState.state === "error") {
-        setMessage(remoteState.value.message);
+        setMessage("Encountered error : " + remoteState.value);
         await shutdown();
     } else if (remoteState.state === "finished") {
         // shutdown the web server, the poller, and close the window
@@ -137,9 +159,10 @@ const pollState = setInterval(async () => {
         await shutdown();
         setMessage("You may now close this window.");
     }
+    state.backendInProgress = false;
 }, config.sleepTime);
 
 // sleep for any number of milliseconds
 const sleep = (milliseconds) => {
-  return new Promise(resolve => setTimeout(resolve, milliseconds))
+    return new Promise(resolve => setTimeout(resolve, milliseconds))
 };


### PR DESCRIPTION
* Removed synchronous blocking frontend backend interactions and instead this now relies entirely on the pollState frontend polling loop
  * Previously there was a mix of frontend backend interactions which were async and one which blocked and waited for other async calls to finish
  * This previous blocking interaction was when the frontend called "/redirect_callback". handle_oidc_redirect_callback
    would then call login.exchange_token_for_credentials which would loop and wait for a separate POST from the frontend to /api/roles to
    complete before login.exchange_token_for_credentials would continue and allow /redirect_callback to return a response to the frontend.
  * This commit removes this behavior so that all frontend to backend interactions are async and the frontends movement through the workflow
    is entirely governed by the changes to the login.state value
  * This new functionality is achieved with the following changes
    * login.exchange_token_for_credentials
      * The method no longer loops, sleeping and waiting for self.role_arn to be set
      * The method now calls self.print_output if it succeeds at getting STS credentials instead of handle_oidc_redirect_callback or login.login
        triggering this as was done previously
      * The method now handles all error cases that it could encounter on its own and returns either "error" if there was a problem, "finished"
        if it succeeded and is done, or "restart_auth" if AWS rejected the ID token and the tool should redirect the user back to the IdP
        to get a new ID token.
    * In cases where the user doesn't provide a role_arn, the set_role function (which is called when the user clicks the role they want and a POST
      is made to /api/roles) is what initiates the login.exchange_token_for_credentials call. This way the user selecting a role is what directly kicks
      off the sequence that ends with credentials being printed on the CLI
* Previously this long running synchronous call to /redirect_callback also kept an eye on how long it had been since the frontend had last made a call
  to /api/state. The way it did this was that while the backend looped, waiting on login.role_arn to get set, it would on each loop check when /api/state
  had last been called. Since we no longer have this loop, this commit adds a new "heartbeat" backend endpoint
  * The "/api/heartbeat" endpoint starts an async long running call that loops and watches to make sure the frontend is awake and polling
  * /api/heartbeat responds every 30 seconds at which point a new call to /api/heartbeat is started. This is just to ensure the browser doesn't give up
    on waiting for the response from the endpoint.
  * This heartbeat call runs in parallel to everything else watching how long it's been since the last call to /api/state and if it's been too long
    the listener kills itself
* This also adds a new behavior in the frontend to accommodate the fully async model which is to track when a backend call is started and completes.
  This is achieved with the new localStorage "backend_in_progress" value. When the frontend is about to call the backend, this is set to prevent later
  async polling to trigger duplicated calls to the same backend endpoint (as the first call hasn't completed yet).
* Instead of killing the flask process in response to error conditions, now the tool instead responds to the frontend to call the /shutdown endpoint
  and that endpoint is responsible for killing the listener. This will remove the potentially scary scenario where the continued execution of logic
  in the tool after an error condition is only prevented by the process being killed instead of returning cleanly and then killing the process.
  To achieve this, some methods that previously returned nothing, now return values to either finish execution early in the case of an error or
  to communicate success.
* In this new model where error cases cause backend calls to complete cleanly, and then for the frontend to call /shutdown, I've removed the "sleep(3600)"
  statements scattered through the code as this isn't needed any more
* Add click check for the case where a user passes --batch but does not provide a --role-arn as well and exit with a usage complaint
* Move the display of the "select a role" message in the frontend to after the role list has been fetched to avoid showing the user a request to select
  a role when there are no roles to select from