### PR TITLE
Change from outputting export to rendering shell script and add shell prompt info

### DIFF
--- a/cloudformation/Makefile
+++ b/cloudformation/Makefile
@@ -32,7 +32,9 @@ deploy-group-role-map-builder:
 		 $(PROD_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME) \
 		 $(GROUP_ROLE_MAP_BUILDER_STACK_NAME) \
 		 $(GROUP_ROLE_MAP_BUILDER_CODE_STORAGE_S3_PREFIX) \
-		 "S3BucketName=$(PROD_S3_BUCKET_NAME) ProviderUrls=$(PROD_PROVIDER_URLS) AmrClaims=$(PROD_AMR_CLAIMS)"
+		 "S3BucketName=$(PROD_S3_BUCKET_NAME) \
+		  ProviderUrls=$(PROD_PROVIDER_URLS) \
+		  AmrClaims=$(PROD_AMR_CLAIMS)"
 
 .PHONE: deploy-group-role-map-builder-dev
 deploy-group-role-map-builder-dev:
@@ -42,7 +44,9 @@ deploy-group-role-map-builder-dev:
 		 $(DEV_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME) \
 		 $(GROUP_ROLE_MAP_BUILDER_STACK_NAME) \
 		 $(GROUP_ROLE_MAP_BUILDER_CODE_STORAGE_S3_PREFIX) \
-		 "S3BucketName=$(DEV_S3_BUCKET_NAME) ProviderUrls=$(DEV_PROVIDER_URLS) AmrClaims=$(DEV_AMR_CLAIMS)"
+		 "S3BucketName=$(DEV_S3_BUCKET_NAME) \
+		  ProviderUrls=$(DEV_PROVIDER_URLS) \
+		  AmrClaims=$(DEV_AMR_CLAIMS)"
 
 .PHONE: deploy-idtoken-for-roles-dev
 deploy-idtoken-for-roles-dev:
@@ -52,7 +56,13 @@ deploy-idtoken-for-roles-dev:
 		 $(DEV_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME) \
 		 $(IDTOKEN_FOR_ROLES_STACK_NAME) \
 		 $(IDTOKEN_FOR_ROLES_CODE_STORAGE_S3_PREFIX) \
-		 "S3BucketName=$(DEV_S3_BUCKET_NAME) CustomDomainName=$(DEV_DOMAIN_NAME) DomainNameZone=$(DEV_DOMAIN_ZONE) CertificateArn=$(DEV_CERT_ARN) AllowedIssuer=$(PROD_ISSUER) AllowedAudience=$(PROD_CLIENT_ID) AllowedMapBuilderSubPrefix=ad|Mozilla-LDAP|" \
+		 "S3BucketName=$(DEV_S3_BUCKET_NAME) \
+		  CustomDomainName=$(DEV_DOMAIN_NAME) \
+		  DomainNameZone=$(DEV_DOMAIN_ZONE) \
+		  CertificateArn=$(DEV_CERT_ARN) \
+		  AllowedIssuer=$(DEV_ISSUER) \
+		  AllowedAudience=$(DEV_CLIENT_ID) \
+		  AllowedMapBuilderSubPrefix=ad|Mozilla-LDAP-Dev|" \
 		 AliasesEndpointUrl
 
 .PHONE: deploy-idtoken-for-roles
@@ -63,7 +73,13 @@ deploy-idtoken-for-roles:
 		 $(PROD_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME) \
 		 $(IDTOKEN_FOR_ROLES_STACK_NAME) \
 		 $(IDTOKEN_FOR_ROLES_CODE_STORAGE_S3_PREFIX) \
-		 "S3BucketName=$(PROD_S3_BUCKET_NAME) CustomDomainName=$(PROD_DOMAIN_NAME) DomainNameZone=$(PROD_DOMAIN_ZONE) CertificateArn=$(PROD_CERT_ARN) AllowedIssuer=$(PROD_ISSUER) AllowedAudience=$(PROD_CLIENT_ID) AllowedMapBuilderSubPrefix=ad|Mozilla-LDAP|" \
+		 "S3BucketName=$(PROD_S3_BUCKET_NAME) \
+		  CustomDomainName=$(PROD_DOMAIN_NAME) \
+		  DomainNameZone=$(PROD_DOMAIN_ZONE) \
+		  CertificateArn=$(PROD_CERT_ARN) \
+		  AllowedIssuer=$(PROD_ISSUER) \
+		  AllowedAudience=$(PROD_CLIENT_ID) \
+		  AllowedMapBuilderSubPrefix=ad|Mozilla-LDAP|" \
 		 AliasesEndpointUrl
 
 .PHONE: test-idtoken-for-roles

--- a/mozilla_aws_cli/login.py
+++ b/mozilla_aws_cli/login.py
@@ -413,6 +413,10 @@ class Login:
                     {ENV_VARIABLE_NAME_MAP[x]: self.credentials[x]
                      for x in self.credentials
                      if x in ENV_VARIABLE_NAME_MAP})
+                output_map.update({
+                    'AWS_PROFILE': None,
+                    'AWS_SHARED_CREDENTIALS_FILE': None,
+                    'MAWS_AWS_PROFILE_NAME': self.profile_name})
             elif self.output == "shared":
                 # Write the credentials
                 path = write_aws_shared_credentials(
@@ -421,13 +425,22 @@ class Login:
                 if path:
                     output_map.update({
                         'AWS_PROFILE': self.profile_name,
-                        'AWS_SHARED_CREDENTIALS_FILE': path})
+                        'AWS_SHARED_CREDENTIALS_FILE': path,
+                        'MAWS_AWS_PROFILE_NAME': None})
+                    output_map.update({
+                        x: None for x in ENV_VARIABLE_NAME_MAP.values()})
             elif self.output == "awscli":
                 # Call into aws a bunch of times
                 if write_aws_cli_credentials(self.profile_name,
                                              self.credentials):
                     if self.profile_name != "default":
-                        output_map.update({'AWS_PROFILE': self.profile_name})
+                        output_map.update({
+                            'AWS_PROFILE': self.profile_name,
+                            'AWS_SHARED_CREDENTIALS_FILE': None,
+                            'MAWS_AWS_PROFILE_NAME': None
+                        })
+                        output_map.update({
+                            x: None for x in ENV_VARIABLE_NAME_MAP.values()})
                 else:
                     logger.error('Unable to write credentials with aws-cli.')
             else:

--- a/mozilla_aws_cli/login.py
+++ b/mozilla_aws_cli/login.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 import time
+import traceback
 import webbrowser
 
 import requests
@@ -396,8 +397,8 @@ class Login:
             else:
                 self.exit("Unable to contact AWS : {}".format(e))
                 return 'error'
-        except Exception as e:
-            self.exit("Unable to contact AWS : {}".format(e))
+        except Exception:
+            self.exit("Unable to contact AWS : {}".format("".join(traceback.format_exception(*sys.exc_info()))))
             return 'error'
 
     def print_output(self):

--- a/mozilla_aws_cli/login.py
+++ b/mozilla_aws_cli/login.py
@@ -447,12 +447,11 @@ class Login:
                 raise ValueError(
                     'Output setting unknown : {}'.format(self.output))
 
-            if output_map:
-                print(output_set_env_vars(output_map))
+            message = "Environment variables set for role {}".format(
+                self.role_arn) if self.print_role_arn else None
 
-            if self.print_role_arn:
-                print("Environment variables set for role {}".format(
-                    self.role_arn), file=sys.stderr)
+            if output_map:
+                print(output_set_env_vars(output_map, message))
 
             if self.web_console:
                 self.aws_federate()

--- a/mozilla_aws_cli/login.py
+++ b/mozilla_aws_cli/login.py
@@ -416,7 +416,7 @@ class Login:
                 output_map.update({
                     'AWS_PROFILE': None,
                     'AWS_SHARED_CREDENTIALS_FILE': None,
-                    'MAWS_AWS_PROFILE_NAME': self.profile_name})
+                    'MAWS_PROMPT': self.profile_name})
             elif self.output == "shared":
                 # Write the credentials
                 path = write_aws_shared_credentials(
@@ -426,7 +426,7 @@ class Login:
                     output_map.update({
                         'AWS_PROFILE': self.profile_name,
                         'AWS_SHARED_CREDENTIALS_FILE': path,
-                        'MAWS_AWS_PROFILE_NAME': None})
+                        'MAWS_PROMPT': self.profile_name})
                     output_map.update({
                         x: None for x in ENV_VARIABLE_NAME_MAP.values()})
             elif self.output == "awscli":
@@ -437,7 +437,7 @@ class Login:
                         output_map.update({
                             'AWS_PROFILE': self.profile_name,
                             'AWS_SHARED_CREDENTIALS_FILE': None,
-                            'MAWS_AWS_PROFILE_NAME': None
+                            'MAWS_PROMPT': self.profile_name
                         })
                         output_map.update({
                             x: None for x in ENV_VARIABLE_NAME_MAP.values()})

--- a/mozilla_aws_cli/role_picker.py
+++ b/mozilla_aws_cli/role_picker.py
@@ -12,19 +12,7 @@ from .cache import read_group_role_map, write_group_role_map
 logger = logging.getLogger(__name__)
 
 PROMPT_BASH_CODE = r'''function maws_profile {
-    if [ -n "${AWS_ACCESS_KEY_ID}" ] &&
-       [ -n "${AWS_SECRET_ACCESS_KEY}" ] &&
-       [ -n "${AWS_SESSION_TOKEN}" ] &&
-       [ -z "${AWS_PROFILE}" ] &&
-       [ -n "${MAWS_AWS_PROFILE_NAME}" ]; then
-        echo " (${MAWS_AWS_PROFILE_NAME})"
-    elif [ -z "${AWS_ACCESS_KEY_ID}" ] &&
-       [ -z "${AWS_SECRET_ACCESS_KEY}" ] &&
-       [ -z "${AWS_SESSION_TOKEN}" ] &&
-       [ -n "${AWS_PROFILE}" ] &&
-       [ -z "${MAWS_AWS_PROFILE_NAME}" ]; then
-        echo " (${AWS_PROFILE})"
-    fi
+    test -n "${MAWS_PROMPT}" && echo " (${MAWS_PROMPT})"
 }
 
 if [ -n "${PS1##*\$(maws_profile)*}" ]; then

--- a/mozilla_aws_cli/role_picker.py
+++ b/mozilla_aws_cli/role_picker.py
@@ -27,7 +27,7 @@ if [ -n "${PS1##*\$(maws_profile)*}" ]; then
 fi'''
 
 
-def output_set_env_vars(var_map):
+def output_set_env_vars(var_map, message=None):
     if platform.system() == "Windows":
         result = "\n".join(
             ["set {}={}".format(x, var_map[x]) for x in var_map])
@@ -42,6 +42,10 @@ def output_set_env_vars(var_map):
             vars_to_unset = [x for x in var_map if var_map[x] is None]
             if vars_to_unset:
                 f.write("unset {}\n".format(" ".join(vars_to_unset)))
+
+            if message is not None:
+                f.write('>&2 echo "{}"\n'.format(message))
+
             f.write("{}\n".format(PROMPT_BASH_CODE))
             f.write("rm -f {}\n".format(name))
             result = "source {}".format(name)

--- a/mozilla_aws_cli/role_picker.py
+++ b/mozilla_aws_cli/role_picker.py
@@ -1,12 +1,40 @@
+import os
+import stat
 import json.decoder
 import logging
 import platform
 import requests
+import tempfile
 
 from .cache import read_group_role_map, write_group_role_map
 
 
 logger = logging.getLogger(__name__)
+
+PROMPT_BASH_CODE = r'''function maws_profile {
+    if [ -n "${AWS_ACCESS_KEY_ID}" ] &&
+       [ -n "${AWS_SECRET_ACCESS_KEY}" ] &&
+       [ -n "${AWS_SESSION_TOKEN}" ] &&
+       [ -z "${AWS_PROFILE}" ] &&
+       [ -n "${MAWS_AWS_PROFILE_NAME}" ]; then
+        echo " (${MAWS_AWS_PROFILE_NAME})"
+    elif [ -z "${AWS_ACCESS_KEY_ID}" ] &&
+       [ -z "${AWS_SECRET_ACCESS_KEY}" ] &&
+       [ -z "${AWS_SESSION_TOKEN}" ] &&
+       [ -n "${AWS_PROFILE}" ] &&
+       [ -z "${MAWS_AWS_PROFILE_NAME}" ]; then
+        echo " (${AWS_PROFILE})"
+    fi
+}
+
+if [ -n "${PS1##*\$(maws_profile)*}" ]; then
+    # maws_profile is missing from PS1
+    if [ "${PS1%\$ }" != "${PS1}" ]; then
+        PS1="${PS1%\$ }\$(maws_profile)\$ "
+    else
+        PS1="${PS1}\$(maws_profile) "
+    fi
+fi'''
 
 
 def output_set_env_vars(var_map):
@@ -14,9 +42,22 @@ def output_set_env_vars(var_map):
         result = "\n".join(
             ["set {}={}".format(x, var_map[x]) for x in var_map])
     else:
-        result = "export"
-        for key in var_map:
-            result += " {}={}".format(key, var_map[key])
+        name = tempfile.mkstemp(suffix='.sh', prefix='maws-')[1]
+        with open(name, 'w') as f:
+            vars_to_set = [
+                "=".join((x, var_map[x]))
+                for x in var_map if var_map[x] is not None]
+            if vars_to_set:
+                f.write("export {}\n".format(" ".join(vars_to_set)))
+            vars_to_unset = [x for x in var_map if var_map[x] is None]
+            if vars_to_unset:
+                f.write("unset {}\n".format(" ".join(vars_to_unset)))
+            f.write("{}\n".format(PROMPT_BASH_CODE))
+            f.write("rm -f {}\n".format(name))
+            result = "source {}".format(name)
+        st = os.stat(name)
+        os.chmod(name, st.st_mode | stat.S_IEXEC)
+
     return result
 
 

--- a/mozilla_aws_cli/role_picker.py
+++ b/mozilla_aws_cli/role_picker.py
@@ -19,6 +19,8 @@ if [ -n "${PS1##*\$(maws_profile)*}" ]; then
     # maws_profile is missing from PS1
     if [ "${PS1%\$ }" != "${PS1}" ]; then
         PS1="${PS1%\$ }\$(maws_profile)\$ "
+    elif [ "${PS1% }" != "${PS1}" ]; then
+        PS1="${PS1% }\$(maws_profile) "
     else
         PS1="${PS1}\$(maws_profile) "
     fi


### PR DESCRIPTION
This changes how the environment variables that maws outputs are conveyed to the parent shell.
Previously a single command was emitted (for non Windows clients) in the form of
"export foo=bar baz=buz"

This is limited to a single command because of how this output is being interpreted by the $(maws)
subshell wrapper.

To work around this limitation maws now produces a temporary shell script which is "sourced" into
the parent shell. This way an arbitrary number of commands can be injected into the parent shell

The temporary shell script
* exports environment variables
* unsets environment variables that should no longer be set
* provisions a function that outputs the current profile name
* modifies the $PS1 prompt to call this function
* deletes itself

This accomplishes two things
* Ensures that a user never ends up with a conflicting set of environment variables (like
  AWS_PROFILE and AWS_ACCESS_KEY_ID) from using one output setting in a given terminal, then using
  a different output setting
* Injects the current profile name into the command prompt so it's clear which account and role
  the user is operating as

Also
* Update dev ID token for role Makefile to use dev IdP
* Improve error messaging for uncaught exceptions