### PR TITLE
Changed issuer URL to contain AWS account alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+* Issuer URL which is used when an AWS web console session expires to enable the
+  user to refresh their session by visiting the federated-aws-rp. Previously the
+  URL shown to the user contained the AWS account ID. Now it contains the more
+  human readable account alias.
 
 ## [0.2.0] - 2019-12-06
 ### Added

--- a/mozilla_aws_cli/login.py
+++ b/mozilla_aws_cli/login.py
@@ -483,8 +483,10 @@ class Login:
             return None
 
         account_id = self.role_arn.split(":")[4]
+        account_alias = self.role_map.get("aliases", {}).get(
+            account_id, [account_id])[0]
         role = self.role_arn.split(':')[5].split('/')[-1]
-        issuer_url_query = urlencode({"account": account_id, "role": role})
+        issuer_url_query = urlencode({"account": account_alias, "role": role})
         issuer_url = urlunparse(
             ('https', self.issuer_domain, '/', '', issuer_url_query, ''))
 


### PR DESCRIPTION
Changed the issuer URL which is used when an AWS web console session expires to enable the
user to refresh their session by visiting the federated-aws-rp. Previously the
URL shown to the user contained the AWS account ID. Now it contains the more
human readable account alias.

Fixes #186