### PR TITLE
Create parent directories for cache and config dirs

### DIFF
--- a/cloudformation/Makefile
+++ b/cloudformation/Makefile
@@ -82,6 +82,18 @@ deploy-idtoken-for-roles:
 		  AllowedMapBuilderSubPrefix=ad|Mozilla-LDAP|" \
 		 AliasesEndpointUrl
 
+.PHONE: create-federated-role-dev
+create-federated-role-dev:
+	aws iam create-role \
+	  --role-name MAWS-test \
+	  --description "Maws Test Role https://github.com/mozilla-iam/mozilla-aws-cli/blob/master/cloudformation/Makefile" \
+	  --max-session-duration 43200 \
+	  --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Federated":"arn:aws:iam::656532927350:oidc-provider/auth-dev.mozilla.auth0.com/"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringEquals":{"auth-dev.mozilla.auth0.com/:aud":"xRFzU2bj7Lrbo3875aXwyxIArdkq1AOT"},"ForAnyValue:StringEquals":{"auth-dev.mozilla.auth0.com/:amr":"team_opsec"}}}]}'
+	aws iam put-role-policy \
+	  --role-name MAWS-test \
+	  --policy-name AllowSTSGetCallerIdentity \
+	  --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"sts:GetCallerIdentity","Resource":"*"}]}'
+
 .PHONE: test-idtoken-for-roles
 test-idtoken-for-roles:
 	URL=`aws cloudformation describe-stacks --stack-name $(IDTOKEN_FOR_ROLES_STACK_NAME) --query "Stacks[0].Outputs[?OutputKey=='AliasesEndpointUrl'].OutputValue" --output text` && \

--- a/mozilla_aws_cli/cache.py
+++ b/mozilla_aws_cli/cache.py
@@ -111,9 +111,13 @@ def _requires_safe_cache_dir(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         if not safe:
-            mode = os.stat(CACHE_DIR).st_mode
-            logger.debug(
-                "Cache directory at {} has invalid permissions of {}.".format(CACHE_DIR, mode))
+            if os.path.exists(CACHE_DIR):
+                mode = os.stat(CACHE_DIR).st_mode
+                logger.debug("Cache directory at {} has invalid permissions "
+                             "of {}.".format(CACHE_DIR, mode))
+            else:
+                logger.debug(
+                    "Cache directory {} doesn't exist".format(CACHE_DIR))
         else:
             return func(*args, **kwargs)
 

--- a/mozilla_aws_cli/cache.py
+++ b/mozilla_aws_cli/cache.py
@@ -422,7 +422,7 @@ def verify_dir_permissions(path=CONFIG_DIR):
         # Attempt to create the directory with the right permissions, if it
         # doesn't exist
         try:
-            os.mkdir(path)
+            os.makedirs(path)
         except (IOError, OSError):
             logger.debug("Unable to create directory: {}".format(path))
             return False

--- a/mozilla_aws_cli/login.py
+++ b/mozilla_aws_cli/login.py
@@ -353,7 +353,7 @@ class Login:
             self.print_output()
             return self.state
         except STSWarning as e:
-            if e.args[1] == "AccessDenied":
+            if len(e.args) > 1 and e.args[1] == "AccessDenied":
                 # Not authorized to perform sts:AssumeRoleWithWebIdentity
                 # Either that role doesn't exist or it exists but doesn't
                 # permit the user because of the conditions
@@ -376,7 +376,7 @@ class Login:
                     self.exit(
                         "Sorry, no valid roles available. Shutting down.")
                     return "error"
-            elif e.args[1] == "ExpiredTokenException":
+            elif len(e.args) > 1 and e.args[1] == "ExpiredTokenException":
                 logger.debug(
                     "AWS says that the ID token is expired : {}".format(e[2]))
                 self.token = None


### PR DESCRIPTION
* Add make target to create a test federated IAM role
* Fix STSWarning handling when the exception doesn't come from boto
* Update safe cache dir check to ensure dir exists as well

Fixes #198
