### PR TITLE
Fix a pair of error handling bugs

### DIFF
--- a/mozilla_aws_cli/role_picker.py
+++ b/mozilla_aws_cli/role_picker.py
@@ -93,7 +93,10 @@ def get_roles_and_aliases(endpoint, token, key, cache=True):
                 "Unable to retrieve role map at: {}. Please check your "
                 "URL.".format(endpoint))
             return None
-        elif "error" in role_map:
+        elif "error" in role_map or "roles" not in role_map:
+            if "message" in role_map and "error" not in role_map:
+                role_map["error"] = role_map["message"]
+
             logging.error(
                 "Unable to retrieve role map: {}".format(role_map["error"]))
             return None

--- a/mozilla_aws_cli/static/index.js
+++ b/mozilla_aws_cli/static/index.js
@@ -151,7 +151,7 @@ const pollState = setInterval(async () => {
         setMessage("Another federation session has been detected. Shutting down.");
         clearInterval(pollState);
     } else if (remoteState.state === "error") {
-        setMessage(`Encountered error : ${remoteState.value}`);
+        setMessage(`Encountered error : ${remoteState.value.message}`);
         await shutdown();
     } else if (remoteState.state === "finished") {
         // shutdown the web server, the poller, and close the window


### PR DESCRIPTION
Fix broken error display and errors where AWS puts `error` into `message` instead. This usually happens when your URL is missing `/roles`.