### PR TITLE
Add js and boto output options

### DIFF
--- a/mozilla_aws_cli/cli.py
+++ b/mozilla_aws_cli/cli.py
@@ -35,7 +35,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.ERROR)
 logging.getLogger("urllib3").propagate = False
 
-VALID_OUTPUT_OPTIONS = ("envvar", "shared", "awscli")
+VALID_OUTPUT_OPTIONS = ("awscli", "boto", "envvar", "js", "shared")
 
 
 def validate_arn(ctx, param, value):


### PR DESCRIPTION
Add JSON formatted output that can be consumed directly by either boto or by the AWS Javascript SDK.