### PR TITLE
Fixes related to maws prompt

### DIFF
--- a/mozilla_aws_cli/cli.py
+++ b/mozilla_aws_cli/cli.py
@@ -200,6 +200,9 @@ def main(batch, config, cache, output, print_url,
     if web_console and print_url:
         raise click.exceptions.UsageError(
             "Cannot print URL to output and redirect to web console")
+    if output in ("awscli", "shared") and profile is None:
+        raise click.exceptions.UsageError(
+            "You must specify a profile name with `awscli` or `shared` output")
 
     logger.debug("Config : {}".format(config))
 

--- a/mozilla_aws_cli/cli.py
+++ b/mozilla_aws_cli/cli.py
@@ -200,9 +200,6 @@ def main(batch, config, cache, output, print_url,
     if web_console and print_url:
         raise click.exceptions.UsageError(
             "Cannot print URL to output and redirect to web console")
-    if output in ("awscli", "shared") and profile is None:
-        raise click.exceptions.UsageError(
-            "You must specify a profile name with `awscli` or `shared` output")
 
     logger.debug("Config : {}".format(config))
 

--- a/mozilla_aws_cli/login.py
+++ b/mozilla_aws_cli/login.py
@@ -412,7 +412,12 @@ class Login:
         # TODO: Create a global config object?
         if self.credentials is not None:
             output_map = {}
+
+            # get a role name (for the command line), and use it for the profile
+            # name if it wasn't manually overridden
             self.role = role_arn_to_display_name(self.role_arn, self.role_map)
+            if self.profile_name is None:
+                self.profile_name = self.role
 
             if self.output == "envvar":
                 output_map.update(

--- a/mozilla_aws_cli/login.py
+++ b/mozilla_aws_cli/login.py
@@ -26,7 +26,7 @@ from .utils import (
     base64_without_padding,
     exit_sigint,
     generate_challenge,
-    role_arn_to_role_name,
+    role_arn_to_display_name,
     STSWarning
 )
 
@@ -412,7 +412,7 @@ class Login:
         # TODO: Create a global config object?
         if self.credentials is not None:
             output_map = {}
-            self.role = role_arn_to_role_name(self.role_arn, self.role_map)
+            self.role = role_arn_to_display_name(self.role_arn, self.role_map)
 
             if self.output == "envvar":
                 output_map.update(

--- a/mozilla_aws_cli/utils.py
+++ b/mozilla_aws_cli/utils.py
@@ -30,7 +30,7 @@ def generate_challenge(code_verifier):
         hashlib.sha256(code_verifier.encode()).digest())
 
 
-def role_arn_to_profile_name(role_arn, role_map):
+def role_arn_to_role_name(role_arn, role_map):
     if not role_map:
         role_map = {}
 

--- a/mozilla_aws_cli/utils.py
+++ b/mozilla_aws_cli/utils.py
@@ -30,7 +30,7 @@ def generate_challenge(code_verifier):
         hashlib.sha256(code_verifier.encode()).digest())
 
 
-def role_arn_to_role_name(role_arn, role_map):
+def role_arn_to_display_name(role_arn, role_map):
     if not role_map:
         role_map = {}
 


### PR DESCRIPTION
* Change prompt to always use role name, never profile name
* Stop overloading `profile_name` and use previously unused `self.role`
* Change function name to indicate actual function
* Fix slightly unrelated bug with using `-o awscli` or `-o shared` without a profile name

Fixes #215.