### PR TITLE
Add check that policy principal account ID is correct

### DIFF
--- a/cloudformation/group_role_map_builder/functions/group_role_map_builder.py
+++ b/cloudformation/group_role_map_builder/functions/group_role_map_builder.py
@@ -271,11 +271,11 @@ def get_groups_from_policy(policy, aws_account_id) -> list:
         if not is_valid_identity_provider(
                 statement.get('Principal', {}).get('Federated'),
                 aws_account_id):
-            logger.debug(
+            logger.error(
                 'Skipping policy statement with Federated Principal {} which '
                 'is not valid'.format(
                     statement.get('Principal', {}).get('Federated')))
-            continue
+            raise InvalidPolicyError
         operator_count = 0
         for operator in statement.get("Condition", {}).keys():
             # StringNotLike, etc. are not supported

--- a/cloudformation/group_role_map_builder/functions/group_role_map_builder.py
+++ b/cloudformation/group_role_map_builder/functions/group_role_map_builder.py
@@ -98,7 +98,8 @@ def is_valid_identity_provider(arn: str, aws_account_id: str) -> bool:
     Check that
     * The ARN is well formatted
     * The AWS Account ID in the ARN is the local Account ID
-    * The suffix of the ARN matches one of the VALID_FEDERATED_PRINCIPLE_URLS with the URL scheme stripped
+    * The suffix of the ARN matches one of the VALID_FEDERATED_PRINCIPLE_URLS
+      with the URL scheme stripped
     :param arn: The ARN of the AWS IAM Identity Provider
     :param aws_account_id: The AWS account ID
     :return: True if the ARN is valid otherwise False
@@ -109,7 +110,8 @@ def is_valid_identity_provider(arn: str, aws_account_id: str) -> bool:
         and elements[:4] == ['arn', 'aws', 'iam', '']
         and elements[4] == aws_account_id
         and elements[5].split('/', 1)[0] == 'oidc-provider'
-        and elements[5].split('/', 1)[1] in [x[8:] for x in get_setting('VALID_FEDERATED_PRINCIPAL_URLS')]
+        and elements[5].split('/', 1)[1] in [
+            x[8:] for x in get_setting('VALID_FEDERATED_PRINCIPAL_URLS')]
     )
 
 

--- a/cloudformation/group_role_map_builder/group_role_map_builder.yaml
+++ b/cloudformation/group_role_map_builder/group_role_map_builder.yaml
@@ -136,7 +136,7 @@ Resources:
           VALID_FEDERATED_PRINCIPAL_URLS: !Ref ProviderUrls
           VALID_AMRS: !Ref AmrClaims
       Handler: group_role_map_builder.lambda_handler
-      Runtime: python3.7
+      Runtime: python3.8
       ReservedConcurrentExecutions: 1
       Role: !GetAtt GroupRoleMapBuilderRole.Arn
       Tags:

--- a/cloudformation/group_role_map_builder/tests/policies/wrong_principal_aws_account_id.json
+++ b/cloudformation/group_role_map_builder/tests/policies/wrong_principal_aws_account_id.json
@@ -5,7 +5,7 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/auth.thisisadifferentidp.auth0.com/"
+        "Federated": "arn:aws:iam::111111111111:oidc-provider/auth.example.auth0.com/"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {

--- a/cloudformation/group_role_map_builder/tests/test_compare_group_arn_maps.py
+++ b/cloudformation/group_role_map_builder/tests/test_compare_group_arn_maps.py
@@ -10,6 +10,7 @@ from moto import mock_s3
 S3_BUCKET_NAME = 'test'
 S3_FILE_NAME = 'test.json'
 
+
 # https://stackoverflow.com/a/23844656/168874
 @mock_s3
 @patch.object(group_role_map_builder, 'emit_event_to_mozdef')

--- a/cloudformation/group_role_map_builder/tests/test_get_groups_from_policy.py
+++ b/cloudformation/group_role_map_builder/tests/test_get_groups_from_policy.py
@@ -47,7 +47,7 @@ def test_all_policies(monkeypatch):
         parsed = policy["parsed"]
 
         if "Returns" in parsed:
-            result = get_groups_from_policy(raw)
+            result = get_groups_from_policy(raw, '123456789012')
             assert (sorted(result) == sorted(parsed["Returns"])), (
                 "Expected {} to return {}. Instead it returned {} where "
                 "VALID_AMRS is {} and VALID_FEDERATED_PRINCIPAL_KEYS is "
@@ -73,7 +73,7 @@ def test_all_policies(monkeypatch):
 
             try:
                 with raises(exception):
-                    get_groups_from_policy(raw)
+                    get_groups_from_policy(raw, '123456789012')
                     pytest.fail(
                         'Expected {} to raise exception {} but it did '
                         'not'.format(policy["filename"], exception))
@@ -86,4 +86,4 @@ def test_all_policies(monkeypatch):
         # These should be things that aren't JSON
         else:
             with raises(InvalidPolicyError):
-                get_groups_from_policy(raw)
+                get_groups_from_policy(raw, '123456789012')

--- a/cloudformation/idtoken_for_roles/functions/idtoken_for_roles.py
+++ b/cloudformation/idtoken_for_roles/functions/idtoken_for_roles.py
@@ -35,10 +35,13 @@ ZERO = timedelta(0)
 class UTC(tzinfo):
     def utcoffset(self, dt):
         return ZERO
+
     def tzname(self, dt):
         return "UTC"
+
     def dst(self, dt):
         return ZERO
+
 
 utc = UTC()
 
@@ -67,7 +70,10 @@ def validate_token(token, key):
         logger.error('Expired JWT signature : {}'.format(e))
         raise TokenValidationError('Expired JWT signature')
     except exceptions.JWTClaimsError as e:
-        logger.error('Invalid claims in ID Token (allowed audience {} allowed issuer {}) : {}'.format(os.getenv('ALLOWED_AUDIENCE'), os.getenv('ALLOWED_ISSUER'), e))
+        logger.error(
+            'Invalid claims in ID Token (allowed audience {} allowed issuer '
+            '{}) : {}'.format(
+                os.getenv('ALLOWED_AUDIENCE'), os.getenv('ALLOWED_ISSUER'), e))
         raise TokenValidationError('Invalid claims in ID Token')
     except exceptions.JWTError as e:
         logger.error('Invalid JWT signature : {}'.format(e))
@@ -128,12 +134,13 @@ def get_roles_and_aliases(token, key, cache):
                 aws_account_id = role.split(':')[4]
                 if (aws_account_id in account_alias_map
                         and aws_account_id not in aliases):
-                    logger.debug('Group {} found in AMR {} adding AWS Account '
-                                 'alias {} for account {}'.format(
-                        group,
-                        id_token['amr'],
-                        account_alias_map[aws_account_id],
-                        aws_account_id))
+                    logger.debug(
+                        'Group {} found in AMR {} adding AWS Account alias {} '
+                        'for account {}'.format(
+                            group,
+                            id_token['amr'],
+                            account_alias_map[aws_account_id],
+                            aws_account_id))
                     aliases[aws_account_id] = account_alias_map[aws_account_id]
             roles.update(mapped_roles)
         else:
@@ -165,14 +172,16 @@ def initiate_group_role_map_rebuild(token, key):
         return {'error': 'GROUP_ROLE_MAP_BUILDER_FUNCTION_NAME is unset'}
     group_role_map_last_modified, group_role_map = get_s3_file(
         S3_BUCKET_NAME, S3_FILE_PATH_GROUP_ROLE_MAP)
-    logger.debug('datetime.now(utc) is {} and group_role_map_last_modified is {}'.format(datetime.now(utc), group_role_map_last_modified))
+    logger.debug(
+        'datetime.now(utc) is {} and group_role_map_last_modified is '
+        '{}'.format(datetime.now(utc), group_role_map_last_modified))
     group_role_map_age = datetime.now(utc) - group_role_map_last_modified
-    # TODO : Here's the problem. This comparison is between the last time the file changed and now
-    # and the file isn't updated if nothing changed
+    # TODO : Here's the problem. This comparison is between the last time the
+    # file changed and now and the file isn't updated if nothing changed
     # so this doesn't stop someone from invoking over and over again
-    # we need make group role map buider touch a file or something indicating that a scan has been done
-    # despite the fact that the json map hasn't changed
-    # or persist this state here in idtokenforroles some other way
+    # we need make group role map buider touch a file or something indicating
+    # that a scan has been done despite the fact that the json map hasn't
+    # changed or persist this state here in idtokenforroles some other way
     seconds_until_next_allowed_rebuild = max(
         0, (60 * 5) - int(group_role_map_age.total_seconds()))
     if seconds_until_next_allowed_rebuild > 0:

--- a/cloudformation/idtoken_for_roles/functions/idtoken_for_roles.py
+++ b/cloudformation/idtoken_for_roles/functions/idtoken_for_roles.py
@@ -128,6 +128,12 @@ def get_roles_and_aliases(token, key, cache):
                 aws_account_id = role.split(':')[4]
                 if (aws_account_id in account_alias_map
                         and aws_account_id not in aliases):
+                    logger.debug('Group {} found in AMR {} adding AWS Account '
+                                 'alias {} for account {}'.format(
+                        group,
+                        id_token['amr'],
+                        account_alias_map[aws_account_id],
+                        aws_account_id))
                     aliases[aws_account_id] = account_alias_map[aws_account_id]
             roles.update(mapped_roles)
         else:

--- a/cloudformation/idtoken_for_roles/idtoken_for_roles.yaml
+++ b/cloudformation/idtoken_for_roles/idtoken_for_roles.yaml
@@ -145,7 +145,7 @@ Resources:
           ALLOWED_MAP_BUILDER_SUB_PREFIX: !Ref AllowedMapBuilderSubPrefix
           GROUP_ROLE_MAP_BUILDER_FUNCTION_NAME: !ImportValue GroupRoleMapBuilderFunctionName
       Handler: idtoken_for_roles.lambda_handler
-      Runtime: python3.7
+      Runtime: python3.8
       Role: !GetAtt IdtokenForRolesFunctionRole.Arn
       Tags:
         - Key: application

--- a/cloudformation/tox.ini
+++ b/cloudformation/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py37, flake8
+envlist = py38, flake8
 skipsdist = true
 
 [testenv:flake8]
-basepython = python3.7
+basepython = python3.8
 deps = flake8
 commands = python -m flake8
 

--- a/mozilla_aws_cli/cache.py
+++ b/mozilla_aws_cli/cache.py
@@ -384,7 +384,7 @@ def read_sts_credentials(role_arn):
                 return sts
             else:
                 logger.debug(
-                    "Cached STS credentials have expired.".format(path))
+                    "Cached STS credentials in {} have expired.".format(path))
                 return None
     except (IOError, OSError):
         logger.debug("Unable to read STS credentials from: {}".format(path))

--- a/mozilla_aws_cli/listener.py
+++ b/mozilla_aws_cli/listener.py
@@ -6,17 +6,10 @@ import socket
 import time
 
 from flask import Flask, jsonify, request, send_from_directory
-import requests.exceptions
 from operator import itemgetter
 
-from .utils import exit_sigint, STSWarning
+from .utils import exit_sigint
 
-try:
-    # P3
-    from urllib.parse import urlencode
-except ImportError:
-    # P2 Compat
-    from urllib import urlencode
 
 # These ports must be configured in the IdP's allowed callback URL list
 # TODO: Move this to the CLI / config section

--- a/mozilla_aws_cli/login.py
+++ b/mozilla_aws_cli/login.py
@@ -4,9 +4,10 @@ import json
 import logging
 import os
 import sys
-import time
 import traceback
 import webbrowser
+
+from future.moves.urllib.parse import urlparse, urlencode, urlunparse
 
 import requests
 
@@ -24,19 +25,10 @@ from .role_picker import (
 )
 from .utils import (
     base64_without_padding,
-    exit_sigint,
     generate_challenge,
     role_arn_to_display_name,
     STSWarning
 )
-
-try:
-    # P3
-    from urllib.parse import urlencode, urlunparse, urlparse
-except ImportError:
-    # P2 Compat
-    from urllib import urlencode
-    from urlparse import urlunparse, urlparse
 
 
 logger = logging.getLogger(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ python =
 [testenv:flake8]
 basepython = python
 deps = flake8
-commands = flake8 federated_aws_cli tests setup.py
+commands = flake8 mozilla_aws_cli tests setup.py
 
 [testenv]
 setenv =


### PR DESCRIPTION
* Add a check that the federated principal in an IAM policy has the same AWS account ID as the account containing the policy.
* Also switch from character offset based checks to delimiter split checks
* Add debug log line for matching groups
* Adding this check as I encountered an invalid policy today that was allowed by maws and rejected by AWS
* Update Lambda functions to Python 3.8