### PR TITLE
Fix bug when AWS Account has no alias

### DIFF
--- a/cloudformation/idtoken_for_roles/functions/idtoken_for_roles.py
+++ b/cloudformation/idtoken_for_roles/functions/idtoken_for_roles.py
@@ -133,15 +133,18 @@ def get_roles_and_aliases(token, key, cache):
             for role in mapped_roles:
                 aws_account_id = role.split(':')[4]
                 if (aws_account_id in account_alias_map
-                        and aws_account_id not in aliases):
-                    logger.debug(
-                        'Group {} found in AMR {} adding AWS Account alias {} '
-                        'for account {}'.format(
-                            group,
-                            id_token['amr'],
-                            account_alias_map[aws_account_id],
-                            aws_account_id))
-                    aliases[aws_account_id] = account_alias_map[aws_account_id]
+                        and len(account_alias_map[aws_account_id]) > 0):
+                    if aws_account_id not in aliases:
+                        logger.debug(
+                            'Group {} found in AMR {} adding AWS Account alias {} '
+                            'for account {}'.format(
+                                group,
+                                id_token['amr'],
+                                account_alias_map[aws_account_id],
+                                aws_account_id))
+                        aliases[aws_account_id] = account_alias_map[aws_account_id]
+                else:
+                    aliases[aws_account_id] = [aws_account_id]
             roles.update(mapped_roles)
         else:
             logger.debug('Group {} not in amr {}'.format(

--- a/mozilla_aws_cli/listener.py
+++ b/mozilla_aws_cli/listener.py
@@ -8,7 +8,7 @@ import time
 from flask import Flask, jsonify, request, send_from_directory
 from operator import itemgetter
 
-from .utils import exit_sigint
+from .utils import exit_sigint, get_alias
 
 
 # These ports must be configured in the IdP's allowed callback URL list
@@ -82,9 +82,7 @@ def get_roles():
             return jsonify({})
     for arn in login.role_map["roles"]:
         account_id = arn.split(":")[4]
-        alias = login.role_map.get(
-            "aliases", {}).get(account_id, [account_id])[0]
-
+        alias = get_alias(login.role_map, account_id)
         role = {
             "alias": alias,
             "arn": arn,

--- a/mozilla_aws_cli/login.py
+++ b/mozilla_aws_cli/login.py
@@ -26,6 +26,7 @@ from .role_picker import (
 from .utils import (
     base64_without_padding,
     generate_challenge,
+    get_alias,
     role_arn_to_display_name,
     STSWarning
 )
@@ -507,8 +508,7 @@ class Login:
             return None
 
         account_id = self.role_arn.split(":")[4]
-        account_alias = self.role_map.get("aliases", {}).get(
-            account_id, [account_id])[0]
+        account_alias = get_alias(self.role_map, account_id)
         role = self.role_arn.split(":")[5].split("/")[-1]
         issuer_url_query = urlencode({"account": account_alias, "role": role})
         issuer_url = urlunparse(

--- a/mozilla_aws_cli/utils.py
+++ b/mozilla_aws_cli/utils.py
@@ -30,6 +30,22 @@ def generate_challenge(code_verifier):
         hashlib.sha256(code_verifier.encode()).digest())
 
 
+def get_alias(role_map, account_id):
+    """Given a role map and account ID return an account alias
+
+    :param role_map: A dictionary containing an 'aliases' key with a map of
+                     account IDs to lists of aliases
+    :param account_id: The AWS account ID number
+    :return: An AWS account alias if it exists or the account ID if not
+    """
+    if ('aliases' in role_map
+            and account_id in role_map['aliases']
+            and len(role_map['aliases'][account_id]) > 0):
+        return role_map['aliases'][account_id][0]
+    else:
+        return account_id
+
+
 def role_arn_to_display_name(role_arn, role_map):
     if not role_map:
         role_map = {}
@@ -41,10 +57,10 @@ def role_arn_to_display_name(role_arn, role_map):
 
     # Get the AWS account id from the role ARN, and then see if it's in the map
     account_id = role_arn.split(":")[4]
-    account_id = role_map.get("aliases", {}).get(account_id, [account_id])[0]
+    alias = get_alias(role_map, account_id)
 
     # such as infosec-somerole
-    return "-".join([account_id, role])
+    return "-".join([alias, role])
 
 
 def strip_xmlns(tag):


### PR DESCRIPTION
Previously, if a user used mozilla-aws-cli with an AWS account that had no account alias
defined, it would respond with errors described in #220 like

```
  File "/path/to/mozilla_aws_cli/listener.py", line 92, in get_roles
    alias = login.role_map.get(
IndexError: list index out of range
```

and

```
  File "/path/to/mozilla_aws_cli/utils.py", line 44, in role_arn_to_display_name
    account_id = role_map.get("aliases", {}).get(account_id, [account_id])[0]
IndexError: list index out of range
```

This commit both changes the ID Token For Roles API to stop returning entries in alias maps with no aliases and updates mozilla-aws-cli to gracefully deal with cases where the ID Token For Roles API returns an empty alias list.

Fixes #220