### PR TITLE
Add MPL 2.0 classifier to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
+        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
         "Natural Language :: English",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",


### PR DESCRIPTION
This PR updates `setup.py` to include the [canonical](https://pypi.org/classifiers/) classifier for the MPL 2.0 license of this repository.