### PR TITLE
Add account id to account name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.4] - 2021-08-12
+
+### Added
+* Show the AWS Account ID for each account on the federated login page.
+  Allows for easier discoverability when tracing Account ID to Account
+  name.
+
 ## [1.2.3] - 2021-04-27
 
 ### Fixed
@@ -145,7 +152,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Initial release of the mozilla-aws-cli tool
 
-[Unreleased]: https://github.com/mozilla-iam/mozilla-aws-cli/compare/v1.2.3...HEAD
+[Unreleased]: https://github.com/mozilla-iam/mozilla-aws-cli/compare/v1.2.4...HEAD
+[1.2.4]: https://github.com/mozilla-iam/mozilla-aws-cli/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/mozilla-iam/mozilla-aws-cli/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/mozilla-iam/mozilla-aws-cli/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/mozilla-iam/mozilla-aws-cli/compare/v1.2.0...v1.2.1

--- a/mozilla_aws_cli/static/index.html
+++ b/mozilla_aws_cli/static/index.html
@@ -26,7 +26,7 @@
 
     <script id="role-picker-template" type="text-/x-handlebars-template">
       {{#each accounts}}
-      <strong>{{@key}}</strong>
+      <strong>{{@key}}</strong> ({{this.[0].id}})
       <ul>
           {{#each this}}
               <li><a data-arn="{{arn}}" data-role="{{role}}" href="#{{arn}}" title="{{id}}">{{role}}</a></li>

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,6 @@ setup(
     tests_require=test_requirements,
     extras_require=extras,
     url="https://github.com/mozilla-iam/mozilla-aws-cli",
-    version="1.2.3",
+    version="1.2.4",
     zip_safe=False,
 )


### PR DESCRIPTION
I am often confused searching the login page for the AWS Account ID that corresponds to the Role I want to select. This simply add the Account ID to the output for faster finding. Open to suggestions or feedback if folks have other workflows that solve this.

*Note* These are not the real account numbers.
![Screenshot_2021-08-12_10-37-10](https://user-images.githubusercontent.com/1072933/129225760-bc230757-5566-43e9-989a-99b97f4b07ec.png)
