### PR TITLE
Unset environment variables more consistently.

### DIFF
--- a/mozilla_aws_cli/login.py
+++ b/mozilla_aws_cli/login.py
@@ -38,6 +38,16 @@ ENV_VARIABLE_NAME_MAP = {
     "SecretAccessKey": "AWS_SECRET_ACCESS_KEY",
     "SessionToken": "AWS_SESSION_TOKEN",
 }
+# List of environment variables that will be cleared if they are not set.
+ENV_VARIABLE_NAMES = [
+    "AWS_ACCESS_KEY_ID",
+    "AWS_PROFILE",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SECURITY_TOKEN",
+    "AWS_SESSION_EXPIRATION",
+    "AWS_SESSION_TOKEN",
+    "AWS_SHARED_CREDENTIALS_FILE",
+]
 
 
 class Login:
@@ -414,13 +424,9 @@ class Login:
 
             if self.output == "envvar":
                 output_map.update(
-                    {ENV_VARIABLE_NAME_MAP[x]: self.credentials[x]
-                     for x in self.credentials
-                     if x in ENV_VARIABLE_NAME_MAP})
-                output_map.update({
-                    "AWS_PROFILE": None,
-                    "AWS_SHARED_CREDENTIALS_FILE": None,
-                    "MAWS_PROMPT": self.display_name})
+                    {var: self.credentials.get(key)
+                     for key, var in ENV_VARIABLE_NAME_MAP.item()})
+                output_map["MAWS_PROMPT"] = self.display_name
             elif self.output == "shared":
                 # Write the credentials
                 path = write_aws_shared_credentials(
@@ -431,18 +437,13 @@ class Login:
                         "AWS_PROFILE": self.profile_name,
                         "AWS_SHARED_CREDENTIALS_FILE": path,
                         "MAWS_PROMPT": self.display_name})
-                    output_map.update({
-                        x: None for x in ENV_VARIABLE_NAME_MAP.values()})
             elif self.output == "awscli":
                 # Call into aws a bunch of times
                 if write_aws_cli_credentials(self.profile_name,
                                              self.credentials):
                     output_map.update({
                         "AWS_PROFILE": self.profile_name,
-                        "AWS_SHARED_CREDENTIALS_FILE": None,
                         "MAWS_PROMPT": self.display_name})
-                    output_map.update({
-                        x: None for x in ENV_VARIABLE_NAME_MAP.values()})
                 else:
                     logger.error("Unable to write credentials with aws-cli.")
             elif self.output == "boto":
@@ -476,6 +477,8 @@ class Login:
                 self.role_arn) if self.print_role_arn else None
 
             if output_map and self.print_output_map:
+                for name in ENV_VARIABLE_NAMES:
+                    output_map.setdefault(name, None)
                 print(output_set_env_vars(output_map, message))
 
             if self.web_console or self.print_url:


### PR DESCRIPTION
We noticed that maws currently does not unset the AWS_SECURITY_TOKEN evnironment variable, which can lead to confusing behaviour if it is still set. This PR makes sure this env variable is always unset, and makes unsetting env vars overall a bit more consistent.

It's not tested at all, and probably needs unit tests, so this is still a draft.