### PR TITLE
Fixes KeyError: 'WERKZEUG_SERVER_FD' error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `KeyError: 'WERKZEUG_SERVER_FD'` error reported in [#243](https://github.com/mozilla-iam/mozilla-aws-cli/issues/243).
   This fix limits the max version of Werkzeug. A more permanent fix will be to
   move away from using the Flask development server to another WSGI listener.
+* Dependent packages that no longer support Python 2.7. For Python 2.7 users
+  older versions of dependent packages are now selected that work with Python
+  2.7.
 
 ## [1.2.4] - 2021-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.5] - 2022-04-12
+
+### Fixed
+* Conflict with Werkzeug version 2.1.0 and newer which caused a 
+  `KeyError: 'WERKZEUG_SERVER_FD'` error reported in [#243](https://github.com/mozilla-iam/mozilla-aws-cli/issues/243).
+  This fix limits the max version of Werkzeug. A more permanent fix will be to
+  move away from using the Flask development server to another WSGI listener.
+
 ## [1.2.4] - 2021-08-12
 
 ### Added
@@ -152,7 +160,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Initial release of the mozilla-aws-cli tool
 
-[Unreleased]: https://github.com/mozilla-iam/mozilla-aws-cli/compare/v1.2.4...HEAD
+[Unreleased]: https://github.com/mozilla-iam/mozilla-aws-cli/compare/v1.2.5...HEAD
+[1.2.5]: https://github.com/mozilla-iam/mozilla-aws-cli/compare/v1.2.4...v1.2.5
 [1.2.4]: https://github.com/mozilla-iam/mozilla-aws-cli/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/mozilla-iam/mozilla-aws-cli/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/mozilla-iam/mozilla-aws-cli/compare/v1.2.1...v1.2.2

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     entry_points={"console_scripts": ["maws=mozilla_aws_cli.cli:main"]},
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ requirements = [
     "appdirs",
     "Click>=6.0",
     "flask>=1.0.2",
+    "Werkzeug<2.1.0",
     "future",
     "requests>=2.20.1",
     "python-jose",
@@ -66,6 +67,6 @@ setup(
     tests_require=test_requirements,
     extras_require=extras,
     url="https://github.com/mozilla-iam/mozilla-aws-cli",
-    version="1.2.4",
+    version="1.2.5",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -3,17 +3,13 @@
 
 """The setup script."""
 
-import sys
 from setuptools import setup, find_packages
 
 with open("README.md") as readme_file:
     readme = readme_file.read()
 
+# https://github.com/mpdavis/python-jose/blob/master/CHANGELOG.md#330----2021-06-04
 # https://github.com/sybrenstuvel/python-rsa/blob/main/CHANGELOG.md#version-43--45---released-2020-06-12
-rsa_version = "<=4.5" if sys.version_info[0] == 2 else ""
-# https://github.com/pytest-dev/pytest-runner/blob/main/CHANGES.rst#v530
-pytest_runner_version = "<5.3" if sys.version_info[0] == 2 else ""
-
 requirements = [
     "appdirs",
     "Click>=6.0",
@@ -21,11 +17,17 @@ requirements = [
     "Werkzeug<2.1.0",
     "future",
     "requests>=2.20.1",
-    "python-jose",
-    "rsa{}".format(rsa_version),
+    "python-jose<3.3.0 ; python_version < '3.0'",
+    "python-jose ; python_version >= '3.0'",
+    "rsa==4.5 ; python_version < '3.0'",
+    "rsa ; python_version >= '3.0'",
     "whichcraft==0.6.1"
 ]
-setup_requirements = ["pytest-runner{}".format(pytest_runner_version)]
+# https://github.com/pytest-dev/pytest-runner/blob/main/CHANGES.rst#v530
+setup_requirements = [
+    "pytest-runner<5.3 ; python_version <'3.0'",
+    "pytest-runner ; python_version >= '3.0'",
+]
 test_requirements = [
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
This fixes a conflict with Werkzeug version 2.1.0 and newer which caused a
`KeyError: 'WERKZEUG_SERVER_FD'`.

This fix limits the max version of Werkzeug. A more permanent fix will be to
move away from using the Flask development server to another WSGI listener.

Fixes #243

Also
* Update classifier to show support up to Python 3.9
* Limit versions of dependent packages to retain python 2.7 support
