### PR TITLE
Add support for AWS IAM Role Trust Relationship statements with multiple actions

### DIFF
--- a/cloudformation/deploy.sh
+++ b/cloudformation/deploy.sh
@@ -27,7 +27,7 @@ fi
 # Confirm that we have access to AWS and we're in the right account
 set +e
 result="$(aws sts get-caller-identity --output text 2>&1)"
-if ! echo "$result" | grep 'arn:aws:sts' >/dev/null; then
+if ! echo "$result" | grep -E 'arn:aws:sts|arn:aws:iam::.*:root' >/dev/null; then
   echo "Error : $result"
   exit 1
 elif ! echo "$result" | grep "$ACCOUNT_ID" >/dev/null; then

--- a/cloudformation/group_role_map_builder/functions/group_role_map_builder.py
+++ b/cloudformation/group_role_map_builder/functions/group_role_map_builder.py
@@ -272,7 +272,7 @@ def get_groups_from_policy(policy, aws_account_id) -> list:
         if not is_valid_identity_provider(
                 statement.get('Principal', {}).get('Federated'),
                 aws_account_id):
-            logger.error(
+            logger.debug(
                 'Skipping policy statement with Federated Principal {} which '
                 'is not valid'.format(
                     statement.get('Principal', {}).get('Federated')))
@@ -282,8 +282,8 @@ def get_groups_from_policy(policy, aws_account_id) -> list:
             # StringNotLike, etc. are not supported
             if operator in UNSUPPORTED_OPERATORS:
                 logger.error(
-                    'UnsupportedPolicyError'
-                    ': Condition uses operator {}'.format(operator))
+                    f'UnsupportedPolicyError : {aws_account_id} '
+                    f': Condition uses operator {operator}')
                 raise UnsupportedPolicyError
             # Is a valid operator and contains a valid :amr entry
             elif operator in VALID_OPERATORS and any(
@@ -295,17 +295,17 @@ def get_groups_from_policy(policy, aws_account_id) -> list:
         # Multiple operators are not supported
         if operator_count > 1:
             logger.error(
-                'UnsupportedPolicyError : Too many ({}) operators used'.format(
-                    operator_count))
+                f'UnsupportedPolicyError : {aws_account_id} : Too many '
+                f'({operator_count}) operators used')
             raise UnsupportedPolicyError
 
-        # An absence of operators means all users are permitted which isn't
+        # An absence of operators may mean all users are permitted which isn't
         # supported
         if operator_count == 0:
             logger.error(
-                'UnsupportedPolicyError : Statement has no amr conditions, '
-                'all users permitted access. At least one amr condition is '
-                'required')
+                f'UnsupportedPolicyError : {aws_account_id} : Statement has '
+                'no supported amr conditions, all users permitted access. At '
+                f'least one supported amr condition is required : {statement}')
             raise UnsupportedPolicyError
 
         # For clarity:

--- a/cloudformation/group_role_map_builder/functions/group_role_map_builder.py
+++ b/cloudformation/group_role_map_builder/functions/group_role_map_builder.py
@@ -262,12 +262,19 @@ def get_groups_from_policy(policy, aws_account_id) -> list:
                 'Skipping policy statement with Effect {}'.format(
                     statement.get("Effect")))
             continue
-        if (statement.get("Action", '').lower()
-                != "sts:AssumeRoleWithWebIdentity".lower()):
+        if type(statement.get("Action", '')) == str and statement.get("Action", '').lower() != "sts:AssumeRoleWithWebIdentity".lower():
             # logger.debug(
             #     'Skipping policy statement with Action {}'.format(
             #         statement.get("Action")))
             continue
+        if type(statement.get("Action")) == list:
+            matching_action_found = False
+            for action in statement["Action"]:
+                if action.lower() == "sts:AssumeRoleWithWebIdentity".lower():
+                    matching_action_found = True
+            if not matching_action_found:
+                # This action list does not contain sts:AssumeRoleWithWebIdentity
+                continue
 
         if not is_valid_identity_provider(
                 statement.get('Principal', {}).get('Federated'),


### PR DESCRIPTION
Previously if an AWS IAM Role Trust relationship contained a statement with multiple actions, the Group Role Map Builder would fail. This fixes that.

Also

* Add support for deploying using an AWS root user
* Clarify log messages to be more accurate